### PR TITLE
Added a Mix.Task to make JS file setup more straightforward and cross-platform REDO

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,21 +181,10 @@ npm install --save vue topbar ../deps/live_vue ../deps/phoenix ../deps/phoenix_h
 rm vendor/topbar.js
 ```
 
-Next, let's copy SSR entrypoint, vite config and typescript config from `live_vue`. If you have any of these files, they'll be skipped so you could update them on your own.
+Next, let's copy SSR entrypoint, vite config and typescript config from `live_vue`. If you have any of these files, they'll be skipped so you could update them on your own. The following is a `mix task` that will do the file changes for you.
 
 ```bash
-mkdir vue
-
-for SOURCE in $(find ../deps/live_vue/assets/copy -type f); do
-  DEST=${SOURCE#../deps/live_vue/assets/copy/}
-
-  if [ -e "$DEST" ]; then
-    echo "SKIPPED $SOURCE -> $DEST. Please update manually"
-  else
-    echo "COPIED $SOURCE -> $DEST"
-    cp $SOURCE $DEST
-  fi
-done
+mix live_vue.setup
 ```
 
 Now we just have to adjust app.js hooks and tailwind config to include `vue` files:

--- a/lib/mix/tasks/setup.ex
+++ b/lib/mix/tasks/setup.ex
@@ -1,0 +1,40 @@
+defmodule Mix.Tasks.LiveVue.Setup do
+  @moduledoc """
+  Copies files from assests/copy of the live_vue dependency to phoenix project assets folder
+  """
+  @shortdoc "copy setup files to assets"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  # Adapted from live_svelte mix task at https://github.com/woutdp/live_svelte/blob/master/lib/mix/tasks/configure_esbuild.ex
+  def run(_args) do
+    Mix.Project.deps_paths(depth: 1)
+    |> Map.fetch!(:live_vue)
+    |> Path.join("assets/copy/**/{*.*}")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.each(fn full_path ->
+      [_beginning, relative_path] = String.split(full_path, "copy", parts: 2)
+      new_path = "assets" <> relative_path
+
+      case File.exists?(new_path) do
+        true ->
+          log_info(~s/Did not copy `#{full_path}` to `#{new_path}` since file already exists/)
+
+        false ->
+          log_info(~s/Copying `#{full_path}` to `#{new_path}`/)
+          Mix.Generator.copy_file(full_path, new_path)
+          log_success(~s/Successfully copied `#{full_path}` to `#{new_path}`/)
+      end
+    end)
+
+    # |> dbg()
+  end
+
+  # Copied from live_svelte logger file at https://github.com/woutdp/live_svelte/blob/master/lib/logger.ex
+  @doc false
+  defp log_info(status), do: Mix.shell().info([status, :reset])
+
+  @doc false
+  defp log_success(status), do: Mix.shell().info([:green, status, :reset])
+end


### PR DESCRIPTION
I used [live_svelte](https://github.com/woutdp/live_svelte/blob/master/lib/mix/tasks/configure_esbuild.ex) to implement the following `mix task`.
```bash
mix live_vue.setup
```
It copies the files from `assets\copy` of [live_vue](https://github.com/Valian/live_vue/tree/main/assets/copy) to the phoenix projects' `assets` folder.
It tries to be verbose by listing the full path of the copy origin and the relative path of the destination. It does not copy the file if the file of the same name in the destination already exists. It lists success or failure for each file.
Also updated the `README.md` to now use the `mix task` instead of the unix shell script with a slight addition to the [step 5](https://github.com/Valian/live_vue?tab=readme-ov-file#installation) description.