### PR TITLE
fix: change counter to count, in example LiveView

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ defmodule LiveVueExamplesWeb.LiveCounter do
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :counter, 0)}
+    {:ok, assign(socket, :count, 0)}
   end
 
   def handle_event("inc", %{"value" => diff}, socket) do


### PR DESCRIPTION
This change was necessary for the example LiveView to render without error.