### PR TITLE
Changed package to an ES module

### DIFF
--- a/assets/js/live_vue/hooks.js
+++ b/assets/js/live_vue/hooks.js
@@ -1,6 +1,6 @@
 import { createApp, createSSRApp, reactive, h } from 'vue'
-import { liveInjectKey } from "./use"
-import { normalizeComponents, getComponent } from './components';
+import { liveInjectKey } from "./use.js"
+import { normalizeComponents, getComponent } from './components.js';
 
 
 function mapValues(object, cb) {

--- a/assets/js/live_vue/index.mjs
+++ b/assets/js/live_vue/index.mjs
@@ -1,2 +1,2 @@
-export { getHooks, initializeVueApp } from "./hooks"
-export { useLiveVue } from "./use"
+export { getHooks, initializeVueApp } from "./hooks.js"
+export { useLiveVue } from "./use.js"

--- a/assets/js/live_vue/server.mjs
+++ b/assets/js/live_vue/server.mjs
@@ -3,7 +3,7 @@ import { createSSRApp, h } from "vue";
 import { renderToString } from "vue/server-renderer";
 import { basename, resolve } from "path";
 import { readFileSync } from "fs";
-import { normalizeComponents, getComponent } from "./components";
+import { normalizeComponents, getComponent } from "./components.js";
 
 function getSlots(slots) {
     const slotFunctions = {}

--- a/assets/js/live_vue/vitePlugin.js
+++ b/assets/js/live_vue/vitePlugin.js
@@ -38,7 +38,7 @@ const jsonMiddleware = (req, res, next) => {
     });
 };
 
-function liveVuePlugin(opts = {}) {
+export default function liveVuePlugin(opts = {}) {
     return {
         name: 'live-vue',
         handleHotUpdate({file, modules, server, timestamp}) {
@@ -98,5 +98,3 @@ function liveVuePlugin(opts = {}) {
         },
     }
 }
-
-module.exports = liveVuePlugin

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "E2E reactivity for Vue and LiveView",
     "license": "MIT",
     "author": "Jakub Skałecki <jakub@skalecki.dev>",
+    "type": "module",
     "module": "./assets/js/live_vue/index.mjs",
     "scripts": {
         "format": "npx prettier --write assets"


### PR DESCRIPTION
I was getting `vue ssr error module not found` errors and ultimately ended up updating the `package.json` to be of `"type": "module"`. This also required updating the `import` and `export` statements. The ssr errors have now stopped for me.