### PR TITLE
resolving index.vue components to directory name. Fixes #22

### DIFF
--- a/assets/js/live_vue/components.js
+++ b/assets/js/live_vue/components.js
@@ -5,7 +5,7 @@ const flatMapKeys = (object, cb) => Object.entries(object).reduce((acc, [key, va
 }, {});
 
 const pathToFullPathAndFilename = (path) => {
-  path = path.replace(".vue", "")
+  path = path.replace("/index.vue", "").replace(".vue", "")
   // both full path and only filename
   return [ path, path.split("/").slice(-1)[0] ]
 }


### PR DESCRIPTION
It should properly resolve `ComponentName/index.vue` files to `ComponentName`. Fixes #22 