### PR TITLE
fix: the dependency error of node.js in mix.deps in example_project

### DIFF
--- a/example_project/mix.exs
+++ b/example_project/mix.exs
@@ -46,7 +46,7 @@ defmodule LiveVueExamples.MixProject do
       {:dns_cluster, "~> 0.1.1"},
       {:bandit, "~> 1.2"},
       {:live_vue, path: ".."},
-      {:nodejs, github: "Valian/elixir-nodejs", branch: "master", override: true}
+      {:nodejs, github: "revelrylabs/elixir-nodejs", branch: "master", override: true}
     ]
   end
 


### PR DESCRIPTION
Hi @Valian , The [document](https://github.com/Valian/live_vue/blob/1590ced01679e729e40732a9d34f6b1af8c75a46/INSTALLATION.md?plain=1#L8)  specifies [elixir-nodejs](https://github.com/revelrylabs/elixir-nodejs) for SSR, but the actual dependency is Valian/elixir-nodejs in example_project. `mix deps.get` will fail.