### PR TITLE
fix: vite polyfill

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -31,7 +31,7 @@ config :live_vue,
   ssr: true
 ```
 
-3. Add config entry to your `config/prod.exs` file
+3. Add a config entry to your `config/prod.exs` file
 
 ```elixir
 config :live_vue,
@@ -55,7 +55,7 @@ defp html_helpers do
 end
 ```
 
-5. LiveVue comes with a handy command to setup all the required files. It won't alter any files you already have in your project, you need to adjust them on your own by looking at the provided sources. Additional instructions how to adjust `package.json` can be found at the end of this page.
+5. LiveVue comes with a handy mix command to setup all the required files. It won't alter any files you already have in your project, you need to adjust them on your own by looking at the provided sources. Additional instructions how to adjust `package.json` can be found at the end of this page.
 
 It will create:
 
@@ -74,10 +74,13 @@ Now we just have to adjust `js/app.js` hooks and tailwind config to include `vue
 
 ```js
 // app.js
+import "vite/modulepreload-polyfill" // recommended vite polyfill
 import topbar from "topbar" // instead of ../vendor/topbar
 import {getHooks} from "live_vue"
 import components from "../vue"
 import "../css/app.css"
+
+
 
 let liveSocket = new LiveSocket("/live", Socket, {
     // ...

--- a/assets/copy/vue/index.js
+++ b/assets/copy/vue/index.js
@@ -1,7 +1,3 @@
-// polyfill recommended by Vite https://vitejs.dev/config/build-options#build-modulepreload
-import "vite/modulepreload-polyfill";
-
-
 // it's a way of importing multiple files in one go with Vite. 
 // we get back a map of components with their relative paths as keys.
 // we're importing from ../../lib to allow collocating Vue files with LiveView files

--- a/example_project/assets/js/app.js
+++ b/example_project/assets/js/app.js
@@ -14,7 +14,8 @@
 //
 //     import "some-package"
 //
-
+// polyfill recommended by Vite https://vitejs.dev/config/build-options#build-modulepreload
+import "vite/modulepreload-polyfill"
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
@@ -25,7 +26,6 @@ import topbar from "topbar"
 import { getHooks } from "live_vue"
 import "../css/app.css"
 import components from "../vue"
-import "vite/modulepreload-polyfill"
 
 // Example integration with Vuetify
 // not importing styles because it conflicts with tailwind, if you want vuetify don't use tailwind

--- a/example_project/assets/vue/index.js
+++ b/example_project/assets/vue/index.js
@@ -1,7 +1,3 @@
-// polyfill recommended by Vite https://vitejs.dev/config/build-options#build-modulepreload
-import "vite/modulepreload-polyfill";
-
-
 // it's a way of importing multiple files in one go with Vite. 
 // we get back a map of components with their relative paths as keys.
 // we're importing from ../../lib to allow collocating Vue files with LiveView files


### PR DESCRIPTION
The vite polyfill which is https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill under the hood should not be loaded in SSR context When doing react SSR it can create transient error I could not reproduce this with vue.
Loading the polyfill only in app.js which live_vue example already does seems the way to go.

I can't reproduce the issue on live_vue but I'm like 99% sure that it's incorrect to load the polyfill in SSR context.

Here is the error for reference it's transient.
```
✘ [ERROR] Missing "./modulepreload-polyfill" specifier in "vite" package [plugin vite:dep-pre-bundle]

    react/index.js:2:7:
      2 │ import "vite/modulepreload-polyfill";
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  This error came from the "onResolve" callback registered here:

    node_modules/esbuild/lib/main.js:1150:20:
      1150 │       let promise = setup({
           ╵                     ^

    at setup (file:///home/john/Projects/elixir/jj/assets/node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:46871:13)
    at handlePlugins (/home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:1150:21)
    at buildOrContextImpl (/home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:873:5)
    at Object.buildOrContext (/home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:699:5)
    at /home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:2032:68
    at new Promise (<anonymous>)
    at Object.context (/home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:2032:27)
    at Object.context (/home/john/Projects/elixir/jj/assets/node_modules/esbuild/lib/main.js:1874:58)
    at prepareEsbuildOptimizerRun (file:///home/john/Projects/elixir/jj/assets/node_modules/vite/dist/node/chunks/dep-DG6Lorbi.js:50861:33)
```