### PR TITLE
Add closing tag to LiveSigil example

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ defmodule ExampleWeb.LiveSigil do
         class="mt-4 bg-black text-white rounded p-2 block">
         Increase counter {{ diff }}
       </button>
+    </template>
     """
   end
 


### PR DESCRIPTION
Noticed there's a missing `</template>` in one of the examples. Great project btw!