### PR TITLE
feature: introduce useLiveEvent composable

### DIFF
--- a/assets/js/live_vue/index.ts
+++ b/assets/js/live_vue/index.ts
@@ -1,6 +1,6 @@
 export type { LiveVueApp, LiveVueOptions, SetupContext, VueComponent, LiveHook, ComponentMap } from "./types.js"
 export { createLiveVue } from "./app.js"
 export { getHooks } from "./hooks.js"
-export { useLiveVue } from "./use.js"
+export { useLiveVue, useLiveEvent } from "./use.js"
 export { findComponent } from "./utils.js"
 export { default as Link } from "./link.js"

--- a/assets/js/live_vue/use.ts
+++ b/assets/js/live_vue/use.ts
@@ -1,4 +1,4 @@
-import { inject } from "vue"
+import { inject, onMounted, onUnmounted } from "vue"
 import type { LiveHook } from "./types.js"
 
 export const liveInjectKey = "_live_vue"
@@ -12,4 +12,23 @@ export const useLiveVue = (): LiveHook => {
   const live = inject<LiveHook>(liveInjectKey)
   if (!live) throw new Error("LiveVue not provided. Are you using this inside a LiveVue component?")
   return live
+}
+
+/**
+ * Registers a callback to be called when an event is received from the server.
+ * It automatically removes the callback when the component is unmounted.
+ * @param event - The event name.
+ * @param callback - The callback to call when the event is received.
+ */
+export function useLiveEvent<T>(event: string, callback: (data: T) => void) {
+  let callbackRef: ReturnType<LiveHook["handleEvent"]> | null = null
+  onMounted(() => {
+    const live = useLiveVue()
+    callbackRef = live.handleEvent(event, callback)
+  })
+  onUnmounted(() => {
+    const live = useLiveVue()
+    if (callbackRef) live.removeHandleEvent(callbackRef)
+    callbackRef = null
+  })
 }

--- a/guides/basic_usage.md
+++ b/guides/basic_usage.md
@@ -87,16 +87,30 @@ There are two ways to access the Phoenix LiveView hook instance from your Vue co
 
 1.  **`useLiveVue()` Composable (in `<script setup>`):**
 
-    Use the `useLiveVue()` composable when you need to access the hook instance for logic within your `<script setup>` block, such as setting up watchers or handling events programmatically.
+    Use the `useLiveVue()` composable when you need to access the hook instance for logic within your `<script setup>` block. It's ideal for pushing events programmatically.
 
     ```html
     <script setup>
     import { useLiveVue } from "live_vue"
+    import { ref } from "vue"
 
     const live = useLiveVue()
+    const name = ref("")
+
+    function save() {
+      live.pushEvent("save", { name: name.value })
+    }
+    </script>
+    ```
+
+    To listen for events from the server, the easiest way is to use the `useLiveEvent` composable, which will automatically handle cleanup for you.
+
+    ```html
+    <script setup>
+    import { useLiveEvent } from "live_vue"
 
     // Example: listening for a server event
-    live.handleEvent("response", (payload) => { console.log(payload) })
+    useLiveEvent("response", (payload) => { console.log(payload) })
     </script>
     ```
 


### PR DESCRIPTION
This PR introduces a new `useLiveEvent` composable to provide a more declarative and convenient way to handle server-pushed events within Vue components.

**Key Changes:**

*   **`useLiveEvent` Composable**: A new `useLiveEvent(event, callback)` composable is now available. It wraps the `live.handleEvent()` logic, automatically registering the event listener on component mount and cleaning it up on unmount. This reduces boilerplate code and prevents potential memory leaks.

 **Documentation Updates**:
    *   `guides/client_api.md` has been significantly restructured. It now has a top-level "Composables" section featuring `useLiveVue` and the new `useLiveEvent`. The lower-level hook methods are now in a "Low-Level API" section.
    *   `guides/basic_usage.md` has been updated to demonstrate `useLiveEvent` as the primary and recommended way to listen for server events.

This change encourages a more robust pattern for handling server events and improves the overall developer experience.