### PR TITLE
feat: introduce useLiveNavigation composable

### DIFF
--- a/assets/js/live_vue/index.ts
+++ b/assets/js/live_vue/index.ts
@@ -1,6 +1,6 @@
 export type { LiveVueApp, LiveVueOptions, SetupContext, VueComponent, LiveHook, ComponentMap } from "./types.js"
 export { createLiveVue } from "./app.js"
 export { getHooks } from "./hooks.js"
-export { useLiveVue, useLiveEvent } from "./use.js"
+export { useLiveVue, useLiveEvent, useLiveNavigation } from "./use.js"
 export { findComponent } from "./utils.js"
 export { default as Link } from "./link.js"

--- a/assets/js/live_vue/use.ts
+++ b/assets/js/live_vue/use.ts
@@ -32,3 +32,43 @@ export function useLiveEvent<T>(event: string, callback: (data: T) => void) {
     callbackRef = null
   })
 }
+
+/**
+ * A composable for navigation.
+ * It uses the LiveSocket instance to navigate to a new location.
+ * Works in the same way as the `live_patch` and `live_redirect` functions in LiveView.
+ * @returns An object with `patch` and `navigate` functions.
+ */
+export const useLiveNavigation = () => {
+  const live = useLiveVue()
+  const liveSocket = live.liveSocket
+  if (!liveSocket) throw new Error("LiveSocket not initialized")
+
+  /**
+   * Patches the current LiveView.
+   * @param hrefOrQueryParams - The URL or query params to navigate to.
+   * @param opts - The options for the navigation.
+   */
+  const patch = (hrefOrQueryParams: string | Record<string, string>, opts: { replace?: boolean } = {}) => {
+    let href = typeof hrefOrQueryParams === "string" ? hrefOrQueryParams : window.location.pathname
+    if (typeof hrefOrQueryParams === "object") {
+      const queryParams = new URLSearchParams(hrefOrQueryParams)
+      href = `${href}?${queryParams.toString()}`
+    }
+    liveSocket.pushHistoryPatch(new Event("click"), href, opts.replace ? "replace" : "push", null)
+  }
+
+  /**
+   * Navigates to a new location.
+   * @param href - The URL to navigate to.
+   * @param opts - The options for the navigation.
+   */
+  const navigate = (href: string, opts: { replace?: boolean } = {}) => {
+    liveSocket.historyRedirect(new Event("click"), href, opts.replace ? "replace" : "push", null, null)
+  }
+
+  return {
+    patch,
+    navigate,
+  }
+}

--- a/guides/client_api.md
+++ b/guides/client_api.md
@@ -51,6 +51,43 @@ useLiveEvent("notification", (payload) => {
 </script>
 ```
 
+### `useLiveNavigation()`
+
+A composable for programmatic navigation that mirrors the functionality of `live_patch` and `live_redirect` in Phoenix LiveView. It returns an object with `patch` and `navigate` functions.
+
+This is useful for scenarios where you need to trigger navigation from your script logic, such as after a form submission or a modal action.
+
+**Returns:**
+- `patch(hrefOrQueryParams, { replace: boolean })`: Patches the current LiveView, similar to `live_patch`.
+- `navigate(href, { replace: boolean })`: Navigates to a new LiveView, similar to `live_redirect`.
+
+**Example: Navigating after a successful action**
+
+```html
+<template>
+  <div>
+    <button @click="goToSettings">Go to Settings</button>
+  </div>
+</template>
+
+<script setup>
+import { useLiveNavigation } from 'live_vue';
+import { useLiveEvent } from 'live_vue';
+
+const { patch, navigate } = useLiveNavigation();
+
+useLiveEvent("user_created", (payload) => {
+  // Redirect to the new user's page
+  navigate(`/users/${payload.id}`);
+})
+
+function goToSettings() {
+  // Update the URL with new query params
+  patch({ tab: 'settings', page: 1 });
+}
+</script>
+```
+
 ## Low-Level API
 
 While composables are recommended for most component-based use cases, you can also access the underlying hook instance for more control or for use outside of components.
@@ -194,19 +231,6 @@ live.pushEventTo("#user-form", "validate", formData)
 // Target component by data attribute
 live.pushEventTo("[data-component='UserProfile']", "refresh")
 
-</script>
-```
-
-**Real-world example - Multi-component dashboard:**
-```html
-<script setup>
-const live = useLiveVue()
-
-const refreshWidget = (widgetId) => {
-  live.pushEventTo(`#widget-${widgetId}`, "refresh", {
-    timestamp: Date.now()
-  })
-}
 </script>
 ```
 


### PR DESCRIPTION
### Summary

This PR introduces the `useLiveNavigation` composable, a new utility for programmatic navigation within Vue components. It provides a more idiomatic, Vue-centric way to perform `live_patch` and `live_redirect` operations, abstracting away the need to interact directly with the `liveSocket` instance.

### `useLiveNavigation()` Composable

The new composable simplifies navigation logic by providing two functions:

-   `patch(hrefOrQueryParams, opts)`: Updates the current LiveView's URL and state, similar to `live_patch`.
-   `navigate(href, opts)`: Redirects to a new LiveView, similar to `live_redirect`.

This aligns with the existing `useLiveEvent` composable and contributes to a more consistent and declarative developer experience when integrating Vue with Phoenix LiveView.

### Example Usage

```vue
<script setup>
import { useLiveNavigation } from 'live_vue';
import { useLiveEvent } from 'live_vue';

const { patch, navigate } = useLiveNavigation();

// Example: Redirect after a server-side event
useLiveEvent("user_created", (payload) => {
  navigate(`/users/${payload.id}`);
});

// Example: Update URL query parameters from a component method
function applyFilters() {
  patch({ status: 'active', page: 1 });
}
</script>
```