### PR TITLE
docs: fix hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See [Installation](guides/installation.md).
 
 This project is heavily inspired by ✨ [LiveSvelte](https://github.com/woutdp/live_svelte) ✨. Both projects try to solve the same problem. LiveVue was started as a fork of LiveSvelte with adjusted ESbuild settings, and evolved to use Vite and a slightly different syntax. I strongly believe more options are always better, and since I love Vue and it's ecosystem I've decided to give it a go 😉
 
-You can read more about differences between Vue and Svelte [in FAQ](#differences-from-livesvelte).
+You can read more about differences between Vue and Svelte [in FAQ](guides/faq.md#how-does-livevue-compare-to-livesvelte) or [in comparison guide](guides/comparison.md).
 
 ## LiveVue Development
 

--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -4,7 +4,7 @@ This guide explains the architecture and inner workings of LiveVue, helping you 
 
 > #### Practical Usage {: .tip}
 >
-> Looking for practical examples? Check out [Basic Usage](basic_usage.html) for common patterns and [Getting Started](getting_started.html) for your first component.
+> Looking for practical examples? Check out [Basic Usage](basic_usage.md) for common patterns and [Getting Started](getting_started.md) for your first component.
 
 ## Overview
 
@@ -130,7 +130,7 @@ This diff-based approach provides several advantages:
 The combination of server-side diff calculation and client-side patch application ensures that LiveVue can handle complex, nested data structures efficiently while maintaining real-time reactivity.
 
 **Disabling Diffs**
-For testing scenarios or debugging purposes, diffing can be disabled globally via the `enable_props_diff: false` configuration option, or per-component using the `v-diff={false}` attribute. When disabled, complete props are always sent instead of diffs, which can be useful for comprehensive testing or troubleshooting complex prop updates. See [Configuration](configuration.html#testing-configuration) for details.
+For testing scenarios or debugging purposes, diffing can be disabled globally via the `enable_props_diff: false` configuration option, or per-component using the `v-diff={false}` attribute. When disabled, complete props are always sent instead of diffs, which can be useful for comprehensive testing or troubleshooting complex prop updates. See [Configuration](configuration.md#testing-configuration) for details.
 
 ## Data Flow
 
@@ -336,6 +336,6 @@ Consider alternatives for simple forms and basic interactions, applications prio
 
 Now that you understand how LiveVue works:
 
-- [Configuration](configuration.html) to customize behavior and SSR settings
-- [Basic Usage](basic_usage.html) for practical patterns and examples
-- [Client-Side API](client_api.html) for detailed API reference
+- [Configuration](configuration.md) to customize behavior and SSR settings
+- [Basic Usage](basic_usage.md) for practical patterns and examples
+- [Client-Side API](client_api.md) for detailed API reference

--- a/guides/basic_usage.md
+++ b/guides/basic_usage.md
@@ -8,7 +8,7 @@ By default, Vue components should be placed in either:
 - `assets/vue` directory
 - Colocated with your LiveView files in `lib/my_app_web`
 
-For advanced component organization and custom resolution patterns, see [Configuration](configuration.html#component-organization).
+For advanced component organization and custom resolution patterns, see [Configuration](configuration.md#component-organization).
 
 ## Rendering Components
 
@@ -93,7 +93,7 @@ end
 
 The encoder protocol ensures that only specified fields are sent to the client, sensitive data is protected, and props can be efficiently diffed for updates.
 
-For complete implementation details including field selection and custom implementations, see [Component Reference](component_reference.html#custom-structs-with-livevue-encoder).
+For complete implementation details including field selection and custom implementations, see [Component Reference](component_reference.md#custom-structs-with-livevue-encoder).
 
 > #### Protocol.UndefinedError {: .warning}
 >
@@ -156,7 +156,7 @@ There are two ways to access the Phoenix LiveView hook instance from your Vue co
     </template>
     ```
 
-The `live` object provides all methods from [Phoenix.LiveView JS Interop](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook). For a complete API reference, see [Client-Side API](client_api.html).
+The `live` object provides all methods from [Phoenix.LiveView JS Interop](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook). For a complete API reference, see [Client-Side API](client_api.md).
 
 ### LiveView Navigation
 
@@ -181,7 +181,7 @@ import { Link } from "live_vue"
 </template>
 ```
 
-For a complete API reference, see [Client-Side API](client_api.html#link).
+For a complete API reference, see [Client-Side API](client_api.md#link).
 
 ### Vue Events
 
@@ -403,7 +403,7 @@ const {
 - **Drag & drop**: Use `addFiles()` method to support drag-and-drop functionality
 - **Cancellation**: Cancel individual files or all uploads
 
-For the complete API reference, see [`useLiveUpload()` in the Client API guide](client_api.html#useliveuploadevent-callback).
+For the complete API reference, see [`useLiveUpload()` in the Client API guide](client_api.md#useliveuploadevent-callback).
 
 ## Dead Views vs Live Views
 
@@ -473,7 +473,7 @@ The `~VUE` sigil is a powerful macro that compiles the string content into a ful
 
 Now that you understand the basics, you might want to explore:
 
-- [Component Reference](component_reference.html) for complete syntax documentation
-- [Configuration](configuration.html) for advanced setup and customization options
-- [Client-Side API](client_api.html) for detailed API reference and advanced patterns
-- [FAQ](faq.html) for common questions and troubleshooting
+- [Component Reference](component_reference.md) for complete syntax documentation
+- [Configuration](configuration.md) for advanced setup and customization options
+- [Client-Side API](client_api.md) for detailed API reference and advanced patterns
+- [FAQ](faq.md) for common questions and troubleshooting

--- a/guides/client_api.md
+++ b/guides/client_api.md
@@ -4,7 +4,7 @@ This guide documents all client-side utilities, composables, and APIs available 
 
 > #### Getting Started {: .tip}
 >
-> New to LiveVue? Check out [Basic Usage](basic_usage.html) for fundamental patterns before diving into the API details.
+> New to LiveVue? Check out [Basic Usage](basic_usage.md) for fundamental patterns before diving into the API details.
 
 ## Composables
 
@@ -183,7 +183,7 @@ const handleDrop = (event) => {
 </template>
 ```
 
-For a complete working example, see [Basic Usage - File Uploads](basic_usage.html#file-uploads).
+For a complete working example, see [Basic Usage - File Uploads](basic_usage.md#file-uploads).
 
 ## Low-Level API
 
@@ -453,7 +453,7 @@ import { Link } from 'live_vue'
 
 ### createLiveVue(config)
 
-Creates a LiveVue application instance. For complete configuration options, see [Configuration](configuration.html#vue-application-setup).
+Creates a LiveVue application instance. For complete configuration options, see [Configuration](configuration.md#vue-application-setup).
 
 ### findComponent(components, name)
 
@@ -659,7 +659,7 @@ useLiveEvent("data_update", (data) => console.log("Data updated:", data))
 
 ## Next Steps
 
-- [Basic Usage](basic_usage.html) for fundamental patterns and examples
-- [Component Reference](component_reference.html) for LiveView-side API
-- [Configuration](configuration.html) for advanced setup options
-- [Testing](testing.html) for testing client-side code
+- [Basic Usage](basic_usage.md) for fundamental patterns and examples
+- [Component Reference](component_reference.md) for LiveView-side API
+- [Configuration](configuration.md) for advanced setup options
+- [Testing](testing.md) for testing client-side code

--- a/guides/component_reference.md
+++ b/guides/component_reference.md
@@ -4,7 +4,7 @@ This guide provides a complete reference for using Vue components in Phoenix Liv
 
 > #### Practical Examples {: .tip}
 >
-> For practical usage examples and patterns, see [Basic Usage](basic_usage.html). This reference focuses on complete syntax documentation.
+> For practical usage examples and patterns, see [Basic Usage](basic_usage.md). This reference focuses on complete syntax documentation.
 
 ## The `.vue` Component
 
@@ -20,7 +20,7 @@ The `.vue` component is the primary way to render Vue components in LiveView tem
 />
 ```
 
-For practical examples of different rendering patterns, see [Basic Usage](basic_usage.html#rendering-components).
+For practical examples of different rendering patterns, see [Basic Usage](basic_usage.md#rendering-components).
 
 ### Required Attributes
 
@@ -185,7 +185,7 @@ Standard Phoenix events work directly in Vue components:
 </.vue>
 ```
 
-For more event handling patterns and examples, see [Basic Usage](basic_usage.html#handling-events).
+For more event handling patterns and examples, see [Basic Usage](basic_usage.md#handling-events).
 
 ### Vue Event Handlers
 
@@ -202,7 +202,7 @@ Use `v-on:` for handling Vue component events:
 />
 ```
 
-For client-side event handling within Vue components, see [Client-Side API](client_api.html#uselivevue).
+For client-side event handling within Vue components, see [Client-Side API](client_api.md#uselivevue).
 
 ### Event Payload Handling
 
@@ -235,7 +235,7 @@ When using `JS.push()` without a value, the emit payload is automatically used:
 
 ### Global SSR Configuration
 
-For complete SSR configuration options, see [Configuration](configuration.html#server-side-rendering-ssr).
+For complete SSR configuration options, see [Configuration](configuration.md#server-side-rendering-ssr).
 
 ### Per-Component SSR Control
 
@@ -256,7 +256,7 @@ LiveVue optimizes performance by sending only prop changes (diffs) instead of co
 
 ### Global Configuration
 
-For complete diffing configuration, see [Configuration - Testing Configuration](configuration.html#testing-configuration).
+For complete diffing configuration, see [Configuration - Testing Configuration](configuration.md#testing-configuration).
 
 ```elixir
 # config/config.exs
@@ -319,7 +319,7 @@ Consider disabling diffing for:
 
 ### Phoenix LiveView Upload Types
 
-Phoenix LiveView upload configurations are automatically encoded for use with the [`useLiveUpload()`](client_api.html#useliveuploadevent-callback) composable:
+Phoenix LiveView upload configurations are automatically encoded for use with the [`useLiveUpload()`](client_api.md#useliveuploadevent-callback) composable:
 
 | Elixir Type | Vue Type | Usage |
 |-------------|----------|-------|
@@ -589,7 +589,7 @@ const createdAt = new Date(props.created_at)
 
 ## Next Steps
 
-- [Basic Usage](basic_usage.html) for practical patterns and examples
-- [Client-Side API](client_api.html) for Vue component development
-- [Configuration](configuration.html) for advanced setup and customization
-- [Testing](testing.html) for testing component integration
+- [Basic Usage](basic_usage.md) for practical patterns and examples
+- [Client-Side API](client_api.md) for Vue component development
+- [Configuration](configuration.md) for advanced setup and customization
+- [Testing](testing.md) for testing component integration

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -405,6 +405,5 @@ Logger.debug("Vue component props: #{inspect(props)}")
 ## Next Steps
 
 With your configuration complete, explore:
-- [Getting Started](getting_started.html) for your first component
-- [Basic Usage](basic_usage.html) for common patterns
-- [Advanced Features](advanced_features.html) for complex scenarios
+- [Getting Started](getting_started.md) for your first component
+- [Basic Usage](basic_usage.md) for common patterns

--- a/guides/deployment.md
+++ b/guides/deployment.md
@@ -4,7 +4,7 @@ Deploying a LiveVue app is similar to deploying a regular Phoenix app, with one 
 
 > #### SSR Configuration {: .tip}
 >
-> For detailed SSR configuration options, see [Configuration](configuration.html#server-side-rendering-ssr). This guide focuses on deployment-specific setup.
+> For detailed SSR configuration options, see [Configuration](configuration.md#server-side-rendering-ssr). This guide focuses on deployment-specific setup.
 
 ## General Requirements
 
@@ -107,7 +107,7 @@ heroku buildpacks:add --index 1 heroku/nodejs
 If using your own Docker setup:
 1. Ensure Node.js 19+ is installed
 2. Follow standard Phoenix deployment practices
-3. Configure SSR for production (see [Configuration](configuration.html#production-ssr-setup))
+3. Configure SSR for production (see [Configuration](configuration.md#production-ssr-setup))
 
 ### Custom Server
 
@@ -124,7 +124,7 @@ apt-get install -y nodejs
 
 - [ ] Node.js 19+ installed
 - [ ] Assets built (`mix assets.build`)
-- [ ] SSR configured properly (see [Configuration](configuration.html#production-ssr-setup))
+- [ ] SSR configured properly (see [Configuration](configuration.md#production-ssr-setup))
 - [ ] Database configured
 - [ ] Environment variables set
 - [ ] SSL certificates configured (if needed)
@@ -137,7 +137,7 @@ apt-get install -y nodejs
 
 1. **SSR Not Working**
    - Verify Node.js installation
-   - Check SSR configuration (see [Configuration](configuration.html#ssr-troubleshooting))
+   - Check SSR configuration (see [Configuration](configuration.md#ssr-troubleshooting))
    - Ensure server bundle exists in `priv/vue/server.js`
 
 2. **Asset Loading Issues**
@@ -146,10 +146,10 @@ apt-get install -y nodejs
    - Inspect network requests
 
 3. **Performance Issues**
-   - Consider adjusting NodeJS pool size (see [Configuration](configuration.html#production-ssr-setup))
+   - Consider adjusting NodeJS pool size (see [Configuration](configuration.md#production-ssr-setup))
 
 ## Next Steps
 
-- Review [FAQ](faq.html) for common questions
+- Review [FAQ](faq.md) for common questions
 - Join our [GitHub Discussions](https://github.com/Valian/live_vue/discussions) for help
 - Consider contributing to [LiveVue](https://github.com/Valian/live_vue)

--- a/guides/faq.md
+++ b/guides/faq.md
@@ -52,7 +52,7 @@ The implementation is straightforward:
 
 Note: Hooks fire only after `app.js` loads, which may cause slight delays in initial render.
 
-For a deeper dive into the architecture, see [Architecture](architecture.html).
+For a deeper dive into the architecture, see [Architecture](architecture.md).
 
 ### What Optimizations Does LiveVue Use?
 
@@ -93,7 +93,7 @@ defmodule User do
 end
 ```
 
-For complete implementation details including field selection, custom implementations, and third-party structs, see [Component Reference](component_reference.html#custom-structs-with-livevue-encoder).
+For complete implementation details including field selection, custom implementations, and third-party structs, see [Component Reference](component_reference.md#custom-structs-with-livevue-encoder).
 
 Without implementing this protocol, you'll get a `Protocol.UndefinedError` when trying to pass custom structs as props. This is by design - it's a safety feature to prevent accidental data exposure.
 
@@ -112,7 +112,7 @@ Important notes:
 - Not needed during live navigation
 - Can be disabled per-component with `v-ssr={false}`
 
-For complete SSR configuration, see [Configuration](configuration.html#server-side-rendering-ssr).
+For complete SSR configuration, see [Configuration](configuration.md#server-side-rendering-ssr).
 
 ### Can I nest LiveVue components inside each other?
 
@@ -178,7 +178,7 @@ import {initApp} from './app.ts'
 initApp()
 ```
 
-For complete TypeScript setup, see [Configuration](configuration.html#typescript-support).
+For complete TypeScript setup, see [Configuration](configuration.md#typescript-support).
 
 ### Where Should I Put Vue Files?
 
@@ -194,7 +194,7 @@ Colocating provides better DX by:
 
 No configuration needed - just place `.vue` files in `lib/my_app_web` and reference them by name or path.
 
-For advanced component organization, see [Configuration](configuration.html#component-organization).
+For advanced component organization, see [Configuration](configuration.md#component-organization).
 
 ## Comparison with Other Solutions
 
@@ -226,7 +226,7 @@ Choose based on:
 - Syntax preferences
 - Bundle size concerns
 
-For a detailed comparison with other solutions, see [Comparison](comparison.html).
+For a detailed comparison with other solutions, see [Comparison](comparison.md).
 
 ## Additional Resources
 

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -59,7 +59,7 @@ live "/counter", CounterLive
 ```
 
 Start server and visit `http://localhost:4000/counter` to see your counter in action!
-If it's not working correctly, see [Troubleshooting](troubleshooting.html).
+If it's not working correctly, see [Troubleshooting](troubleshooting.md).
 
 ## Adding Smooth Transitions
 
@@ -157,7 +157,7 @@ Basic diagram of the flow:
 
 ![LiveVue flow](./images/lifecycle.png)
 
-If you want to understand how it works in depth, see [Architecture](architecture.html).
+If you want to understand how it works in depth, see [Architecture](architecture.md).
 
 ### Working with Custom Structs
 
@@ -183,7 +183,7 @@ This protocol ensures that:
 - Sensitive data is protected from accidental exposure
 - Props can be efficiently diffed for optimal performance
 
-For more details, see [Component Reference](component_reference.html#custom-structs-with-livevue-encoder).
+For more details, see [Component Reference](component_reference.md#custom-structs-with-livevue-encoder).
 
 
 > #### Good to know {: .info}
@@ -196,7 +196,7 @@ For more details, see [Component Reference](component_reference.html#custom-stru
 ## Next Steps
 
 Now that you have your first component working, explore:
-- [Basic Usage](basic_usage.html) for more patterns and the ~VUE sigil
-- [Component Reference](component_reference.html) for complete syntax documentation
-- [FAQ](faq.html) for common questions and troubleshooting
-- [Troubleshooting](troubleshooting.html) for common issues
+- [Basic Usage](basic_usage.md) for more patterns and the ~VUE sigil
+- [Component Reference](component_reference.md) for complete syntax documentation
+- [FAQ](faq.md) for common questions and troubleshooting
+- [Troubleshooting](troubleshooting.md) for common issues

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -277,8 +277,8 @@ defmodule User do
 end
 ```
 
-This is a safety feature to prevent accidental exposure of sensitive data. For more details, see [Component Reference](component_reference.html#custom-structs-with-livevue-encoder).
+This is a safety feature to prevent accidental exposure of sensitive data. For more details, see [Component Reference](component_reference.md#custom-structs-with-livevue-encoder).
 
 ## Next Steps
 
-Now that you have LiveVue installed, check out our [Getting Started Guide](getting_started.html) to create your first Vue component!
+Now that you have LiveVue installed, check out our [Getting Started Guide](getting_started.md) to create your first Vue component!

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -4,7 +4,7 @@ This guide helps you diagnose and fix common issues when working with LiveVue.
 
 > #### Quick Start {: .tip}
 >
-> New to LiveVue? Start with [Getting Started](getting_started.html) for a working example, then check [Basic Usage](basic_usage.html) for common patterns.
+> New to LiveVue? Start with [Getting Started](getting_started.md) for a working example, then check [Basic Usage](basic_usage.md) for common patterns.
 
 ## Component Issues
 
@@ -120,7 +120,7 @@ This guide helps you diagnose and fix common issues when working with LiveVue.
    %{name: "John", email: "john@example.com"}
    ```
 
-For complete implementation details including field selection and custom implementations, see [Component Reference](component_reference.html#custom-structs-with-livevue-encoder).
+For complete implementation details including field selection and custom implementations, see [Component Reference](component_reference.md#custom-structs-with-livevue-encoder).
 
 **Common Causes:**
 - Passing structs without implementing the encoder protocol
@@ -291,7 +291,7 @@ config :live_vue,
   ssr: true
 ```
 
-For complete SSR configuration options, see [Configuration](configuration.html#server-side-rendering-ssr).
+For complete SSR configuration options, see [Configuration](configuration.md#server-side-rendering-ssr).
 
 **Verify Node.js version:**
 ```bash
@@ -314,7 +314,7 @@ children = [
 ls priv/vue/server.js  # Should exist after build
 ```
 
-For production SSR setup details, see [Configuration](configuration.html#production-ssr-setup).
+For production SSR setup details, see [Configuration](configuration.md#production-ssr-setup).
 
 ## Performance Issues
 
@@ -452,7 +452,7 @@ export default defineConfig({
 ### Before Asking for Help
 
 1. **Check browser console for errors**
-2. **Verify all configuration steps** (see [Configuration](configuration.html))
+2. **Verify all configuration steps** (see [Configuration](configuration.md))
 3. **Test with minimal reproduction case**
 4. **Check if issue exists in example project**
 
@@ -475,7 +475,7 @@ Include:
 
 ## Next Steps
 
-- [FAQ](faq.html) for conceptual questions
-- [Architecture](architecture.html) to understand how things work
-- [Configuration](configuration.html) for advanced setup options
+- [FAQ](faq.md) for conceptual questions
+- [Architecture](architecture.md) to understand how things work
+- [Configuration](configuration.md) for advanced setup options
 - [GitHub Issues](https://github.com/Valian/live_vue/issues) to report bugs


### PR DESCRIPTION
Whilst looking at the documentation via GitHub (which is very common for me and for a bunch of people, I would say) I've found that some links were broken due to being with .html extension instead of .md.

HexDocs already points our Markdown files to proper HTML files so, this way, documentation can be read both via GitHub or HexDocs smoothly. I have ran `mix docs` to ensure that everything is correctly working, but this might need a double check :D

Thanks for you great work here with LiveVue.