### PR TITLE
feat: add shared_props configuration for automatic prop injection to Vue components

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,4 +18,11 @@ config :live_vue,
 
   # if false, we will always update full props and not send diffs
   # defaults to true as it greatly reduces payload size
-  enable_props_diff: true
+  enable_props_diff: true,
+
+  # list of props that should be automatically added to all Vue components
+  # their value is taken from socket assigns
+  # examples:
+  #   [:current_user]  # socket.assigns.current_user → prop current_user
+  #   [{:theme, :ui_theme}]  # socket.assigns.ui_theme → prop theme
+  shared_props: []

--- a/example_project/config/config.exs
+++ b/example_project/config/config.exs
@@ -32,3 +32,8 @@ config :phoenix, :json_library, Jason
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
+
+config :live_vue,
+  shared_props: [
+    :flash
+  ]

--- a/example_project/lib/live_vue_examples_web/live/slots.ex
+++ b/example_project/lib/live_vue_examples_web/live/slots.ex
@@ -18,6 +18,9 @@ defmodule LiveVueExamplesWeb.LiveSlots do
   end
 
   def handle_event("add-tag", _, socket) do
-    {:noreply, update(socket, :tags, &(&1 ++ [Enum.random(["nice", "wow", "so cool"])]))}
+    tag = Enum.random(["nice", "wow", "so cool"])
+    # flash is a shared prop, so it's always available for Vue components
+    socket = put_flash(socket, :info, "Tag #{tag} added")
+    {:noreply, update(socket, :tags, &(&1 ++ [tag]))}
   end
 end

--- a/test/live_vue_test.exs
+++ b/test/live_vue_test.exs
@@ -7,6 +7,8 @@ defmodule LiveVueTest do
 
   alias LiveVue.Test
   alias Phoenix.LiveView.JS
+  alias Phoenix.LiveView.Socket
+  alias Phoenix.LiveView.Socket.AssignsNotInSocket
 
   doctest LiveVue
 
@@ -229,5 +231,198 @@ defmodule LiveVueTest do
 
       assert vue.slots == %{}
     end
+  end
+
+  describe "merge_socket_props" do
+    test "merges simple atom props from socket" do
+      # Create socket with no changes (same current and previous assigns)
+      socket = create_socket(%{current_user: "john", theme: "dark"})
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+      config = [:current_user, :theme]
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "john"
+      assert result[:theme] == "dark"
+      assert result[:existing_prop] == "value"
+      assert result[:"v-socket"] == socket
+      # we shouldn't add any changed props, since original socket changed didn't have it
+      assert result.__changed__ == %{}
+    end
+
+    test "returns assigns unchanged when socket is missing" do
+      assigns = %{existing_prop: "value", __changed__: %{}}
+      config = [:current_user]
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result == assigns
+    end
+
+    test "returns assigns unchanged when socket is nil" do
+      assigns = %{"v-socket": nil, existing_prop: "value", __changed__: %{}}
+      config = [:current_user]
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result == assigns
+    end
+
+    test "returns assigns unchanged when props config is empty" do
+      socket = create_socket(%{current_user: "john"})
+      assigns = %{"v-socket": socket, existing_prop: "value"}
+      config = []
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result == assigns
+    end
+
+    test "merges props with tuple configuration {socket_key, prop_name}" do
+      socket = create_socket(%{current_scope: "admin", user_id: 123})
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+      config = [{:current_scope, :scope}, {:user_id, :id}]
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:scope] == "admin"
+      assert result[:id] == 123
+      assert result[:existing_prop] == "value"
+      assert result[:"v-socket"] == socket
+      assert result.__changed__ == %{}
+    end
+
+    test "preserves __changed__ tracking when socket has changes" do
+      socket =
+        create_socket(
+          # we changed jane to john
+          %{current_user: "john", theme: "dark"},
+          %{current_user: "jane", theme: "dark"}
+        )
+
+      config = [:current_user, :theme]
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "john"
+      assert result[:theme] == "dark"
+      # __changed__ should track that current_user changed from "jane"
+      assert result.__changed__[:current_user] == true
+      # theme should not be in __changed__ since socket didn't track it as changed
+      refute Map.has_key?(result.__changed__, :theme)
+    end
+
+    test "handles complex __changed__ tracking with tuple config" do
+      socket =
+        create_socket(
+          # current assigns
+          %{current_scope: "admin", user_data: %{name: "john"}},
+          # previous assigns (what changed)
+          %{current_scope: "user", user_data: %{name: "jane"}}
+        )
+
+      config = [{:current_scope, :scope}, {:user_data, :user}]
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:scope] == "admin"
+      assert result[:user] == %{name: "john"}
+      # __changed__ should contain the previous values from socket.__changed__
+      # simple values get true
+      assert result.__changed__[:scope] == true
+      # complex values get the previous value
+      assert result.__changed__[:user] == %{name: "jane"}
+    end
+
+    test "ignores __changed__ tracking when assigns has no __changed__" do
+      socket = create_socket(%{current_user: "john"}, %{current_user: "jane"})
+
+      config = [:current_user]
+      assigns = %{"v-socket": socket, existing_prop: "value"}
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "john"
+      assert result[:existing_prop] == "value"
+      # No __changed__ key should be present
+      refute Map.has_key?(result, :__changed__)
+    end
+
+    test "ignores __changed__ tracking when socket has no __changed__" do
+      socket = create_socket(%{current_user: "john"})
+      {_, socket} = pop_in(socket, [Access.key!(:assigns), Access.key!(:__assigns__), Access.key!(:__changed__)])
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+      config = [:current_user]
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "john"
+      assert result[:existing_prop] == "value"
+      # __changed__ should remain unchanged since socket has no changes
+      assert result.__changed__ == %{}
+    end
+
+    test "raises error with invalid configuration" do
+      socket = create_socket(%{current_user: "john"})
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+
+      assert_raise RuntimeError, ~r/Invalid shared prop config: "invalid"/, fn ->
+        LiveVue.merge_socket_props(["invalid"], assigns)
+      end
+
+      assert_raise RuntimeError, ~r/Invalid shared prop config: \{:a, :b, :c\}/, fn ->
+        LiveVue.merge_socket_props([{:a, :b, :c}], assigns)
+      end
+    end
+
+    test "handles non-existent socket keys gracefully" do
+      socket = create_socket(%{current_user: "john"})
+      config = [:current_user, :non_existent_key, {:missing_key, :mapped_name}]
+      assigns = %{"v-socket": socket, existing_prop: "value", __changed__: %{}}
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "john"
+      assert result[:non_existent_key] == nil
+      assert result[:mapped_name] == nil
+      assert result[:existing_prop] == "value"
+      assert result.__changed__ == %{}
+    end
+
+    test "keeps existing props when socket has given prop" do
+      socket = create_socket(%{current_user: "socket_user", theme: "dark"})
+      config = [:current_user, :theme]
+      assigns = %{"v-socket": socket, current_user: "assigns_user", theme: "light", __changed__: %{}}
+
+      result = LiveVue.merge_socket_props(config, assigns)
+
+      assert result[:current_user] == "assigns_user"
+      assert result[:theme] == "light"
+      assert result.__changed__ == %{}
+    end
+
+    test "works with non-LiveView.Socket structs" do
+      fake_socket = %{some: "data"}
+      assigns = %{"v-socket": fake_socket, existing_prop: "value"}
+
+      result = LiveVue.merge_socket_props([:current_user], assigns)
+
+      # Should return unchanged since socket is not a Phoenix.LiveView.Socket
+      assert result == assigns
+    end
+  end
+
+  defp create_socket(assigns, previous_assigns \\ nil) do
+    previous_assigns = if previous_assigns == nil, do: assigns, else: previous_assigns
+    previous_assigns = Map.put(previous_assigns, :__changed__, %{})
+    socket = %Socket{assigns: previous_assigns}
+
+    socket =
+      Enum.reduce(assigns, socket, fn {key, value}, acc ->
+        # we're doing assigns using LiveView to make sure we're not breaking
+        Phoenix.Component.assign(acc, key, value)
+      end)
+
+    %{socket | assigns: %AssignsNotInSocket{__assigns__: socket.assigns}}
   end
 end


### PR DESCRIPTION
## Add shared_props configuration for automatic prop injection

  This PR introduces a new `shared_props` configuration option that allows automatic
  injection of common props to all Vue components, eliminating the need to manually pass
  repetitive data.

  ### Key Changes

  - **New Configuration**: Added `shared_props` config option that accepts :atoms or {:source, :destination} tuples
  - **Automatic Injection**: Shared props are automatically merged with component-specific
  props
  - **Comprehensive Testing**: Added extensive test coverage for all shared_props scenarios

  ### Usage Examples

  ```elixir
  # Static shared props
  config :live_vue, shared_props: [
    :flash, 
    {:current_scope, :scope}
  ]
```

  Benefits

  - Reduces boilerplate code in LiveView templates
  - Centralizes common prop management
  - Maintains component-specific prop override capability
  - Zero breaking changes to existing functionality

Closes #42 