### PR TITLE
feat: Add support for configuration of a public facing vite host

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,6 +12,13 @@ config :live_vue,
   # in dev most likely http://localhost:5173
   vite_host: nil,
 
+  # The public facing hostname of vite
+  # in most scenarios we don't need this and it will default to :vite_host
+  # If you run a docker setup for development you might it,
+  # because the containers will communicate over a docker network
+  # while the browser needs a public facing URL
+  vite_public_host: nil,
+
   # it's relative to LiveVue.SSR.NodeJS.server_path, so "priv" directory
   # that file is created by Vite "build-server" command
   ssr_filepath: "./static/server.mjs",

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -23,6 +23,10 @@ config :live_vue,
   # Typically http://localhost:5173 in development
   vite_host: nil,
 
+  # Vite development public facing server URL
+  # Typically it will default to :vite_host while it might be needed in containerized environment
+  vite_public_host: nil
+
   # SSR server bundle path (relative to priv directory)
   # Created by Vite "build-server" command
   ssr_filepath: "./static/server.mjs",
@@ -383,6 +387,9 @@ The server bundle will be created at `priv/static/server.mjs` and used by the No
 - Consider adjusting the NodeJS pool size based on your server capacity
 - Disable SSR for components that don't benefit from it
 
+**Do you run vite dev server behind a proxy?**
+- Use `:vite_public_host` in combination with `:vite_host` to distinguish between inter-container communication and browser-to-container communication
+
 ## Shared Props Configuration
 
 LiveVue offers a configuration option that enables developers to specify props that are automatically passed to all Vue components. This feature ensures consistent data availability across components without the need to manually pass props in every instance.
@@ -463,7 +470,7 @@ defineProps(['flash', 'user', 'locale'])
 ### Common Issues
 
 1. **Components not found**: Check `vue_root` paths in `LiveVue.Components`
-2. **SSR errors**: Verify `ssr_module` and `vite_host` configuration
+2. **SSR errors**: Verify `ssr_module`, `vite_host` and `vite_public_host` configuration
 3. **TypeScript errors**: Ensure proper `tsconfig.json` setup
 4. **Build failures**: Check Vite configuration and entry points
 

--- a/lib/live_vue/reload.ex
+++ b/lib/live_vue/reload.ex
@@ -16,14 +16,15 @@ defmodule LiveVue.Reload do
       assigns
       |> assign(:stylesheets, for(path <- assigns.assets, String.ends_with?(path, ".css"), do: path))
       |> assign(:javascripts, for(path <- assigns.assets, String.ends_with?(path, ".js"), do: path))
+      |> assign(:public_host, Application.get_env(:live_vue, :vite_public_host) || Application.get_env(:live_view, :vite_host))
 
-    # TODO - maybe make it configurable in other way than by presence of vite_host config?
+      # TODO - maybe make it configurable in other way than by presence of vite_host config?
     ~H"""
-    <%= if Application.get_env(:live_vue, :vite_host) do %>
-      <script type="module" src={LiveVue.SSR.ViteJS.vite_path("@vite/client")}>
+    <%= if @public_host do %>
+      <script type="module" src={LiveVue.SSR.ViteJS.vite_path("@vite/client", true)}>
       </script>
-      <link :for={path <- @stylesheets} rel="stylesheet" href={LiveVue.SSR.ViteJS.vite_path(path)} />
-      <script :for={path <- @javascripts} type="module" src={LiveVue.SSR.ViteJS.vite_path(path)}>
+      <link :for={path <- @stylesheets} rel="stylesheet" href={LiveVue.SSR.ViteJS.vite_path(path, true)} />
+      <script :for={path <- @javascripts} type="module" src={LiveVue.SSR.ViteJS.vite_path(path, true)}>
       </script>
     <% else %>
       {render_slot(@inner_block)}

--- a/lib/live_vue/ssr/vite_js.ex
+++ b/lib/live_vue/ssr/vite_js.ex
@@ -47,16 +47,25 @@ defmodule LiveVue.SSR.ViteJS do
 
   @doc """
   A handy utility returning path relative to Vite JS host.
+  Dependent on the parameter flag `public`, the Vite JS host will be `:vite_host` or `:vite_public_host`
   """
-  def vite_path(path) do
-    case Application.get_env(:live_vue, :vite_host) do
+  def vite_path(path, public \\ false) do
+    vite_host = case public do
+      false -> Application.get_env(:live_vue, :vite_host)
+      true -> Application.get_env(:live_vue, :vite_public_host)
+      _ -> raise %LiveVue.SSR.NotConfigured{message: "Unknown Parameter for `public`: #{public}"}
+    end
+
+    case vite_host do
       nil ->
         message = """
-        Vite.js host is not configured. Please add the following to config/dev.ex
+        Vite.js host or public host is not configured. Please add the following to config/dev.ex
 
         config :live_vue, vite_host: "http://localhost:5173"
 
-        and ensure vite.js is running
+        The vite_public_host will default to vite_host if not explicitly configured otherwise.
+
+        Also ensure vite.js is running.
         """
 
         raise %LiveVue.SSR.NotConfigured{message: message}


### PR DESCRIPTION
Adds the optional configuration key vite_public_host 
- If vite_public_host is not set, vite_host will get used 
- Changes LiveVue.Reload#vite_path/1 to LiveVue.Reload#vite_path/2 with a second parameter which defaults to false and can be set to true to get a path relative to vite_public_host instead of vite_host 
- Adjusts config/config.exs and guides/configuration.md accordingly

Fixes this issue: https://github.com/Valian/live_vue/issues/83

There is a request in the mentioned issue for letting the new host config default to `vite_host`. I do not know how to do that in a library, never worked on one before. What I did instead is, because `vite_public_host` is called at one point only, is to check there if it is present and if not, taking `vite_host` instead. 