### PR TITLE
Use correct path for includes

### DIFF
--- a/lib/mix/tasks/live_vue.install.ex
+++ b/lib/mix/tasks/live_vue.install.ex
@@ -285,6 +285,12 @@ defmodule Mix.Tasks.LiveVue.Install do
     end
 
     defp update_tsconfig_for_vue(igniter) do
+      app_path_name = 
+        igniter 
+        |> Igniter.Project.Application.app_name() 
+        |> to_string() 
+        |> Macro.underscore()
+
       igniter
       |> Igniter.rm("assets/tsconfig.json")
       |> Igniter.create_new_file("tsconfig.json", """
@@ -306,7 +312,7 @@ defmodule Mix.Tasks.LiveVue.Install do
         "include": [
           "./assets/js/**/*",
           "./assets/vue/**/*",
-          "./lib/my_app_web/**/*"
+          "./lib/#{app_path}_web/**/*"
         ],
         "exclude": [
           "node_modules"


### PR DESCRIPTION
While playing/testing around with your library I found that the paths for the tsconfig includes were set to a default static path.

The change should reflect the regular naming convention of the web folder based in the application name/module.

Not sure if this line is required at all since this is related to typescript settings (?) but in case that it is required its now set to the correct path.