### PR TITLE
fix: installer skipping html_helpers modification for LiveVue* projects

### DIFF
--- a/lib/mix/tasks/live_vue.install.ex
+++ b/lib/mix/tasks/live_vue.install.ex
@@ -75,8 +75,10 @@ defmodule Mix.Tasks.LiveVue.Install do
 
       Igniter.update_file(igniter, web_file, fn source ->
         Rewrite.Source.update(source, :content, fn content ->
-          # Check if LiveVue is already added to avoid duplicate additions
-          if String.contains?(content, "use LiveVue") do
+          # Check if LiveVue is already added to avoid duplicate additions.
+          # Use regex to match "use LiveVue" as a standalone module, not as part of
+          # another module name (e.g., "use LiveVueWebsiteWeb" should not match).
+          if Regex.match?(~r/use LiveVue\b/, content) do
             content
           else
             # Get the short module name (without Elixir. prefix)


### PR DESCRIPTION
## Summary

- Fixed idempotency check in `add_live_vue_to_html_helpers` that was incorrectly matching project web modules like `use LiveVueWebsiteWeb`
- Changed from `String.contains?(content, "use LiveVue")` to `Regex.match?(~r/use LiveVue\b/, content)` to use word boundary matching

## Problem

When installing LiveVue into a project named `live_vue_website`, the installer would find `use LiveVueWebsiteWeb, :controller` in the `*_web.ex` file and incorrectly conclude that LiveVue was already installed, skipping the `use LiveVue` injection into `html_helpers`.

## Test plan

- [ ] Run `mix igniter.install live_vue --dry-run` on a fresh Phoenix project named `live_vue_*`
- [ ] Verify `use LiveVue` appears in the `.igniter` diff for the `*_web.ex` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)