### PR TITLE
Fix: ensure slots containing non-ASCII characters display correctly

### DIFF
--- a/assets/js/live_vue/hooks.test.ts
+++ b/assets/js/live_vue/hooks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { ref, reactive, type App } from "vue"
 import { getVueHook } from "./hooks"
 import type { LiveVueApp, Hook } from "./types"
+import { toUtf8Base64 } from "./utils"
 
 // Mock Vue component for testing
 const MockComponent = {
@@ -139,7 +140,7 @@ describe("getVueHook", () => {
     })
 
     it("should parse slots from data-slots attribute", async () => {
-      const mockSlots = { default: btoa("<p>Slot content</p>") }
+      const mockSlots = { default: toUtf8Base64("<p>😸Slot content😸</p>") }
       mockHookContext.el.getAttribute.mockImplementation((name: string) => {
         if (name === "data-name") return "TestComponent"
         if (name === "data-slots") return JSON.stringify(mockSlots)
@@ -279,8 +280,8 @@ describe("getVueHook", () => {
 
     it("should update slots", () => {
       const newSlots = {
-        default: btoa("<p>Updated slot content</p>"),
-        header: btoa("<h1>Header</h1>"),
+        default: toUtf8Base64("<p>Updated slot content</p>"),
+        header: toUtf8Base64("<h1>Header</h1>"),
       }
 
       mockHookContext.el.getAttribute.mockImplementation((name: string) => {

--- a/assets/js/live_vue/hooks.ts
+++ b/assets/js/live_vue/hooks.ts
@@ -2,7 +2,7 @@ import { createApp, createSSRApp, h, reactive, type App } from "vue"
 import { migrateToLiveVueApp } from "./app.js"
 import type { ComponentMap, LiveVueApp, LiveVueOptions, Hook } from "./types.js"
 import { liveInjectKey } from "./use.js"
-import { mapValues } from "./utils.js"
+import { mapValues, fromUtf8Base64 } from "./utils.js"
 import { applyPatch, type Operation } from "./jsonPatch.js"
 
 /**
@@ -20,7 +20,7 @@ const getAttributeJson = (el: HTMLElement, attributeName: string): Record<string
  */
 const getSlots = (el: HTMLElement): Record<string, () => any> => {
   const dataSlots = getAttributeJson(el, "data-slots") || {}
-  return mapValues(dataSlots, base64 => () => h("div", { innerHTML: atob(base64).trim() }))
+  return mapValues(dataSlots, base64 => () => h("div", { innerHTML: fromUtf8Base64(base64).trim() }))
 }
 
 const getDiff = (el: HTMLElement, attributeName: string): Operation[] => {

--- a/assets/js/live_vue/utils.test.ts
+++ b/assets/js/live_vue/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { findComponent } from "./utils"
+import { findComponent, toUtf8Base64, fromUtf8Base64 } from "./utils"
 import type { ComponentMap } from "./types"
 
 describe("findComponent", () => {
@@ -122,7 +122,7 @@ describe("findComponent", () => {
       "../../lib/live_vue/web/pages/workspace/index.vue": MockWorkspaceComponent,
       "../../lib/live_vue/web/pages/workspace.vue": MockCreateWorkspaceComponent,
     }
-    
+
     expect(() => findComponent(components, "workspace")).toThrow("Component 'workspace' is ambiguous")
   })
 
@@ -132,5 +132,26 @@ describe("findComponent", () => {
     }
 
     expect(() => findComponent(components, "")).toThrow("Component '' not found!")
+  })
+})
+
+describe("base64 functions", () => {
+
+  it("should symmetrically encode to and decode from base64", () => {
+    for (const input of ["", "Hello!", "Wrocław", "🦡", "中國"]) {
+      const base64 = toUtf8Base64(input);
+      expect(fromUtf8Base64(base64)).toEqual(input);
+    }
+  })
+
+  it("should decode bas 64 strings encoded by Elixir", () => {
+    for (const [base64, decoded] of [
+      ["", ""],
+      ["Q2Fmw6k=", "Café"],
+      ["8J+SgEZlZGVyaWNh", "💀Federica"],
+      ["5YiY5oWI5qyj", "刘慈欣"]
+    ]) {
+      expect(fromUtf8Base64(base64)).toEqual(decoded);
+    }
   })
 })

--- a/assets/js/live_vue/utils.ts
+++ b/assets/js/live_vue/utils.ts
@@ -390,3 +390,28 @@ export function deepEqual(a: any, b: any): boolean {
 export function sanitizeId(input: string): string {
   return input.replace(/\./g, "_").replace(/\[|\]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "")
 }
+
+/**
+ * Takes a string that has been encoded in UTF-8 and then Base64 and returns
+ * a decoded JS string.
+ */
+export const fromUtf8Base64 = (base64: string) => {
+  // atob decodes the Base64 string, but returns each UTF-8 byte as an ASCII
+  // character. So we need to get the values of these characters, put them in
+  // a Uint8Array and then decode that back into a string. Ideally, we'd use
+  // the Uint8Array.fromBase64 function, but this isn't widely available yet
+  const utf8AsciiString = atob(base64);
+  const utf8Uint8Array = new Uint8Array(utf8AsciiString.length);
+  for (let i = 0; i < utf8AsciiString.length; i++) {
+    utf8Uint8Array[i] = utf8AsciiString.charCodeAt(i);
+  }
+  return new TextDecoder("utf-8").decode(utf8Uint8Array);
+}
+
+/**
+ * Encodes a JS string in UTF-8 and Base64. Only here for testing purposes!
+ */
+export const toUtf8Base64 = (str: string) => {
+  const utf8Uint8Array = new TextEncoder().encode(str);
+  return btoa(String.fromCharCode(...utf8Uint8Array));
+}


### PR DESCRIPTION
On the Elixir side of things, the contents of slots are encoded into UTF-8 and then into Base64. Prior to this fix, the client side code was then decoding them with `atob`, which can only really handle ASCII, leading to anything with non-ASCII char displaying as an unexpected string of characters.

This change should fix that, by adding an extra step to decode the UTF-8 into JS strings. I haven't actually been able to verify it as yet, because I can't get the example project to start properly, but I thought you might appreciate the implementation and unit tests even so.
