### PR TITLE
Update comment on toUtf8Base64 to clarify why it's test-only

### DIFF
--- a/assets/js/live_vue/utils.ts
+++ b/assets/js/live_vue/utils.ts
@@ -409,7 +409,10 @@ export const fromUtf8Base64 = (base64: string) => {
 }
 
 /**
- * Encodes a JS string in UTF-8 and Base64. Only here for testing purposes!
+ * Encodes a JS string in UTF-8 and Base64. Only here for testing purposes:
+ * because it uses the spread operator, it will break on strings whose
+ * UTF-8 encoding is longer than 64KiB, so it is NOT suitable for production
+ * use!
  */
 export const toUtf8Base64 = (str: string) => {
   const utf8Uint8Array = new TextEncoder().encode(str);


### PR DESCRIPTION
Possibly being a bit paranoid but I wanted to ensure that no-one picked this up down the line and started using it outside controlled testing environments, and I thought the best way to do that was to explain why it's not production ready.

Apologies for the PR noise: I realised I hadn't been very clear about this just after the original PR was merged!