### PR TITLE
docs: review and improve guides for 1.0 launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ test/e2e/                    # Playwright tests with Phoenix server
 ```
 
 ### Vue Composables (TypeScript)
-- `useLive()` - Access to `$live.pushEvent()`, props
+- `useLiveVue()` - Access to `$live.pushEvent()`, props
 - `useLiveEvent(name, handler)` - LiveView event subscription
 - `useLiveNavigation()` - `patch()` and `navigate()` helpers
 - `useLiveForm(formName)` - Server-side validation with Ecto

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Vue inside Phoenix LiveView with seamless end-to-end reactivity.
 
 ## Resources
 
+-   [Live Examples](https://livevue.skalecki.dev) - Interactive demos
 -   [HexDocs](https://hexdocs.pm/live_vue)
 -   [HexPackage](https://hex.pm/packages/live_vue)
 -   [Phoenix LiveView](https://github.com/phoenixframework/phoenix_live_view)
@@ -181,17 +182,16 @@ mix expublish.minor --dry-run --allow-untracked --branch=main
 mix expublish.minor --allow-untracked --branch=main
 ```
 
-## Roadmap 🎯
+## Features Implemented 🎯
 
-
-- [x] `useLiveEvent` - an utility automatically attaching & detaching [`handleEvent`](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook)
-- [x] ~~optimize payload - send only [`json_patch`](https://hexdocs.pm/jsonpatch/readme.html) diffs of updated props~~ ✅ **Done!**
-- [x] shared props automatically included in all components
-- [x] VS code extension highlighting `~VUE` sigil ✅ **Done!**
-- [x] ~~try to use [Igniter](https://hexdocs.pm/igniter/) as a way of installing LiveVue in a project~~ ✅ **Done!**
-- [x] `useEventReply` - an utility similar to [`useFetch`](https://vueuse.org/core/useFetch/) making it easy to get data from `&handle_event/3 -> {:reply, data, socket}` responses
-- [x] `useLiveForm` - an utility to effortlessly use Ecto changesets & server-side validation, similar to HEEX ✅ **Done!**
-- [x] **Phoenix Streams** - Full support for `stream()` operations with transparent patches ✅ **Done!**
+- [x] `useLiveEvent` - automatically attaching & detaching [`handleEvent`](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook)
+- [x] JSON Patch diffing - send only changed props over the WebSocket
+- [x] Shared props - automatically included in all components
+- [x] VS Code extension - syntax highlighting for `~VUE` sigil
+- [x] Igniter installer - one-line installation for Phoenix 1.8+ projects
+- [x] `useEventReply` - easy handling of `{:reply, data, socket}` responses
+- [x] `useLiveForm` - Ecto changesets & server-side validation
+- [x] Phoenix Streams - full support for `stream()` operations
 
 ## Credits
 

--- a/guides/basic_usage.md
+++ b/guides/basic_usage.md
@@ -338,9 +338,11 @@ const {
         Choose Files
       </button>
 
-      <!-- Manual upload for non-auto uploads -->
+      <!-- Manual upload button - only shown when auto_upload is false -->
+      <!-- In this example, auto_upload: true is set on the server, so this won't display -->
+      <!-- Include this pattern when you want to support both auto and manual upload modes -->
       <button
-        v-if="!upload.auto_upload && entries.length > 0"
+        v-if="!props.upload.auto_upload && entries.length > 0"
         @click="submit"
         class="btn-success"
       >
@@ -403,7 +405,7 @@ const {
 - **Drag & drop**: Use `addFiles()` method to support drag-and-drop functionality
 - **Cancellation**: Cancel individual files or all uploads
 
-For the complete API reference, see [`useLiveUpload()` in the Client API guide](client_api.md#useliveuploadevent-callback).
+For the complete API reference, see [`useLiveUpload()` in the Client API guide](client_api.md#useliveuploaduploadconfig-options).
 
 ## Phoenix Streams
 

--- a/guides/client_api.md
+++ b/guides/client_api.md
@@ -871,9 +871,9 @@ LiveVue provides full TypeScript support for Phoenix LiveView's `AsyncResult` st
 `AsyncResult<T>` represents the state of an asynchronous operation (like `assign_async`, `stream_async`, or `start_async`) with the following fields:
 
 - `ok`: Boolean indicating if the operation has completed successfully at least once
-- `loading`: Loading state - can be `null`, `string[]` (list of keys from `assign_async`), or custom loading data
-- `failed`: Error state - unwrapped from Elixir error tuples for JSON compatibility
-- `result`: The successful result data of type `T`
+- `loading`: Loading state - `string[]` (list of loading keys from `assign_async`) or `null` when not loading
+- `failed`: Error state - unwrapped from Elixir error tuples for JSON compatibility, or `null` if no error
+- `result`: The successful result data of type `T`, or `null` if not yet loaded
 
 ### Usage Examples
 
@@ -897,13 +897,9 @@ if (props.userResult.ok && props.userResult.result) {
   console.log('User:', props.userResult.result.name)
 }
 
-// Handle different loading states
-if (props.userResult.loading === true) {
-  console.log('Loading...')
-} else if (Array.isArray(props.userResult.loading)) {
-  console.log('Loading keys:', props.userResult.loading) // ['users', 'posts']
-} else if (props.userResult.loading) {
-  console.log('Custom loading state:', props.userResult.loading)
+// Handle loading states
+if (props.userResult.loading) {
+  console.log('Loading keys:', props.userResult.loading) // e.g., ['user']
 }
 
 // Handle errors (automatically unwrapped from {:error, reason} tuples)
@@ -1102,33 +1098,6 @@ const debouncedSearch = debounce((query: string) => {
 }, 300)
 
 watch(searchQuery, debouncedSearch)
-</script>
-```
-
-### Event Cleanup
-
-```html
-<script setup lang="ts">
-import { useLiveVue } from 'live_vue'
-import { onMounted, onUnmounted } from 'vue'
-
-const live = useLiveVue()
-
-// Helper function to clean up event listeners
-// will likely be added to LiveVue in the future
-export function useLiveEvent(event, callback) {
-  let callbackRef = null
-  onMounted(() => {
-    callbackRef = live.handleEvent(event, callback)
-  })
-  onUnmounted(() => {
-    if (callbackRef) live.removeHandleEvent(callbackRef)
-    callbackRef = null
-  })
-}
-
-
-useLiveEvent("data_update", (data) => console.log("Data updated:", data))
 </script>
 ```
 

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -300,28 +300,26 @@ All integrations have similar server load characteristics since they use LiveVie
 ## Community and Ecosystem
 
 ### LiveSvelte
-- **Stars**: ~1.5k GitHub stars
 - **Maturity**: Most mature integration
 - **Community**: Active development and community
 - **Documentation**: Comprehensive with examples
 
 ### LiveVue
-- **Stars**: ~330 GitHub stars
 - **Maturity**: Stable and well-documented
 - **Community**: Growing community
 - **Documentation**: Extensive guides and examples
 
 ### LiveReact
-- **Stars**: ~260 GitHub stars
 - **Maturity**: Recently reached v1.0
 - **Community**: Active development
 - **Documentation**: Good documentation
 
 ### LiveState
-- **Stars**: ~260 GitHub stars
 - **Maturity**: Stable for specific use cases
 - **Community**: Focused on embeddable apps
 - **Documentation**: Good for target use cases
+
+For current GitHub star counts, check each project's repository directly.
 
 ## Conclusion
 

--- a/guides/component_reference.md
+++ b/guides/component_reference.md
@@ -354,7 +354,20 @@ defmodule User do
   @derive {LiveVue.Encoder, except: [:password, :secret_key]}
   defstruct [:name, :email, :password, :secret_key]
 end
+
+# For Ecto schemas with associations that may not be loaded
+defmodule Post do
+  use Ecto.Schema
+  @derive {LiveVue.Encoder, except: [:__meta__], nillify_not_loaded: true}
+
+  schema "posts" do
+    field :title, :string
+    belongs_to :author, User  # Will be nil if not preloaded, instead of raising
+  end
+end
 ```
+
+The `nillify_not_loaded: true` option converts Ecto's `%Ecto.Association.NotLoaded{}` structs to `nil` instead of raising an error. This is useful when you want to pass Ecto schemas as props without always preloading all associations.
 
 #### Custom Implementation
 

--- a/guides/faq.md
+++ b/guides/faq.md
@@ -36,7 +36,7 @@ The implementation is straightforward:
    - Event handlers configured
    - SSR content (when enabled)
 
-2. **Initialization**: The [LiveVue hook](https://github.com/Valian/live_vue/blob/main/assets/js/live_vue/hooks.js):
+2. **Initialization**: The [LiveVue hook](https://github.com/Valian/live_vue/blob/main/assets/js/live_vue/hooks.ts):
    - Mounts on element creation
    - Sets up event handlers
    - Injects the hook for `useLiveVue`
@@ -73,8 +73,9 @@ LiveVue implements several performance optimizations:
    - Enables efficient JSON patch calculations (using [Jsonpatch](https://github.com/corka149/jsonpatch) library)
    - Reduces payload sizes by sending only changed fields
 
-4. **Coming Soon**:
-   - Sending only updated props
+4. **JSON Patch Diffing**:
+   - Only changed props are sent over the WebSocket
+   - Uses JSON Patch format for minimal payloads
 
 ### What is the LiveVue.Encoder Protocol?
 
@@ -159,13 +160,10 @@ Since the nested component's HTML is just inert markup at that point, Phoenix Li
 
 ### How Do I Use TypeScript?
 
-LiveVue provides full TypeScript support:
-
-1. Use the example `tsconfig.json`
-2. Check `example_project/assets/ts_config_example` for:
-   - LiveVue entrypoint
-   - Tailwind setup
-   - Vite config
+LiveVue provides full TypeScript support out of the box. The Igniter installer sets up TypeScript automatically with proper configuration for:
+- Vue single-file components with `<script setup lang="ts">`
+- Type-safe props with `defineProps<T>()`
+- LiveVue composables with full type inference
 
 For `app.js`, since it's harder to convert directly:
 ```javascript
@@ -230,7 +228,7 @@ For a detailed comparison with other solutions, see [Comparison](comparison.md).
 
 ## Additional Resources
 
+- [LiveVue Examples](https://livevue.skalecki.dev) - Live demo website with interactive examples
 - [GitHub Discussions](https://github.com/Valian/live_vue/discussions)
-- [Example Project](https://github.com/Valian/live_vue/tree/main/example_project)
 - [Vue Documentation](https://vuejs.org/)
 - [Phoenix LiveView Documentation](https://hexdocs.pm/phoenix_live_view)

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -196,6 +196,7 @@ For more details, see [Component Reference](component_reference.md#custom-struct
 ## Next Steps
 
 Now that you have your first component working, explore:
+- [Live Examples](https://livevue.skalecki.dev) - Interactive demos to see LiveVue in action
 - [Basic Usage](basic_usage.md) for more patterns and the ~VUE sigil
 - [Component Reference](component_reference.md) for complete syntax documentation
 - [FAQ](faq.md) for common questions and troubleshooting

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -63,8 +63,6 @@ This will automatically configure your project with all necessary LiveVue setup.
 >
 > Manual installation instructions are currently outdated and don't work with current versions of dependencies (Tailwind, Phoenix, etc).
 >
-> If you need manual installation for LiveVue <= 0.7, see the [v0.7 documentation](https://hexdocs.pm/live_vue/0.7.3/installation.html).
->
 > **We strongly recommend using the Igniter installation above.**
 
 The manual installation process involves many complex steps including:

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -278,6 +278,10 @@ npm run build
      ]
    ```
 
+3. **Understand HMR scope:**
+   - **Vue files**: Hot Module Replacement works seamlessly - changes to `.vue` files are reflected instantly without page refresh
+   - **Elixir files**: Changes to `.ex` and `.heex` files trigger a LiveView re-render via Phoenix's code reloading, not Vite HMR. This still provides fast feedback but works through LiveView's WebSocket connection rather than Vite's HMR
+
 ## SSR Issues
 
 ### SSR Not Working
@@ -454,7 +458,7 @@ export default defineConfig({
 1. **Check browser console for errors**
 2. **Verify all configuration steps** (see [Configuration](configuration.md))
 3. **Test with minimal reproduction case**
-4. **Check if issue exists in example project**
+4. **Create a fresh project with Igniter to verify the issue isn't in your configuration**
 
 ### Where to Get Help
 
@@ -475,6 +479,7 @@ Include:
 
 ## Next Steps
 
+- [Live Examples](https://livevue.skalecki.dev) - Working examples to compare against
 - [FAQ](faq.md) for conceptual questions
 - [Architecture](architecture.md) to understand how things work
 - [Configuration](configuration.md) for advanced setup options


### PR DESCRIPTION
## Summary

- Review all guides against actual implementation for 1.0 launch readiness
- Fix documentation issues, broken links, and unclear explanations
- Remove references to example_project (being replaced by live website)
- Add links to livevue.skalecki.dev live examples

## Changes

### Configuration & API Documentation
- Add `gettext_backend` config option documentation
- Clarify SSR "dead renders" behavior with explanatory note
- Add `nillify_not_loaded: true` option documentation for Ecto associations
- Add complete nested shared props example
- Add `lazy_html` test dependency requirement

### Forms Guide Improvements
- Clarify `action: :validate` is required for changeset error display
- Clarify `prepareData` applies to both validation and submission events
- Fix radio button pattern to use proper `{ type: 'radio', value: '...' }` field options
- Improve `useField`/`useArrayField` error documentation with actual error message

### Troubleshooting & DX
- Add HMR scope explanation (Vue files vs Elixir files)
- Fix broken `useLiveUpload` link anchor in basic_usage.md
- Fix `useLive()` -> `useLiveVue()` terminology

### Cleanup
- Remove all `example_project` references (replaced by live website)
- Remove stale GitHub star counts from comparison guide
- Add clarifying comments to auto_upload example

### Live Examples
- Add links to https://livevue.skalecki.dev across guides:
  - README.md (Resources section)
  - getting_started.md (Next Steps)
  - faq.md (Additional Resources)
  - forms.md (Complex Nested Form section)
  - troubleshooting.md (Next Steps)

## Test plan

- [ ] Verify all internal links work correctly
- [ ] Verify live example links resolve
- [ ] Review rendered markdown on HexDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)