### PR TITLE
test: add unit tests to improve code coverage

### DIFF
--- a/test/live_vue_internals_test.exs
+++ b/test/live_vue_internals_test.exs
@@ -1,0 +1,631 @@
+defmodule LiveVueInternalsTest do
+  use ExUnit.Case
+
+  import Phoenix.Component
+
+  alias LiveVue.Test
+  alias Phoenix.LiveView.LiveStream
+
+  # Test module for Encoder protocol
+  defmodule ItemWithoutId do
+    @moduledoc false
+    @derive LiveVue.Encoder
+    defstruct [:name, :value]
+  end
+
+  defmodule ItemWithId do
+    @moduledoc false
+    @derive LiveVue.Encoder
+    defstruct [:id, :name]
+  end
+
+  # Utility function to render Vue assigns and get parsed Vue properties
+  defp render_vue_assigns(assigns) do
+    rendered = LiveVue.vue(assigns)
+    html = rendered |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+    Test.get_vue(html)
+  end
+
+  # Utility function to decode patches
+  defp decode_patch(patch_list) do
+    patch_list
+    |> Enum.map(fn patch ->
+      case patch do
+        [op, path] -> %{"op" => op, "path" => path}
+        [op, path, value] -> %{"op" => op, "path" => path, "value" => value}
+      end
+    end)
+    |> Enum.reject(fn patch -> patch["op"] == "test" end)
+  end
+
+  # Utility function to assert JSON patches are equal by sorting both by path
+  defp assert_patches_equal(actual, expected) do
+    actual_uncompressed = decode_patch(actual)
+    actual_sorted = Enum.sort_by(actual_uncompressed, & &1["path"])
+    expected_sorted = Enum.sort_by(expected, & &1["path"])
+    assert actual_sorted == expected_sorted
+  end
+
+  describe "object_hash/1 - when map doesn't have :id key" do
+    test "returns nil for maps without id field" do
+      assigns = %{
+        items: [
+          %{name: "Alice", value: 1},
+          %{name: "Bob", value: 2}
+        ],
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      # Reorder items - without id field, this will cause more operations
+      assigns =
+        assign(assigns, :items, [
+          %{name: "Bob", value: 2},
+          %{name: "Alice", value: 1}
+        ])
+
+      vue = render_vue_assigns(assigns)
+
+      # Without id field, the diff algorithm treats items differently
+      # It should see these as replacements rather than reordering
+      expected_patches = [
+        %{"op" => "replace", "path" => "/items/0/name", "value" => "Bob"},
+        %{"op" => "replace", "path" => "/items/0/value", "value" => 2},
+        %{"op" => "replace", "path" => "/items/1/name", "value" => "Alice"},
+        %{"op" => "replace", "path" => "/items/1/value", "value" => 1}
+      ]
+
+      assert_patches_equal(vue.props_diff, expected_patches)
+    end
+
+    test "handles structs without id field" do
+      assigns = %{
+        items: [
+          %ItemWithoutId{name: "item1", value: 10},
+          %ItemWithoutId{name: "item2", value: 20}
+        ],
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      # Change the first item
+      assigns =
+        assign(assigns, :items, [
+          %ItemWithoutId{name: "updated", value: 15},
+          %ItemWithoutId{name: "item2", value: 20}
+        ])
+
+      vue = render_vue_assigns(assigns)
+
+      expected_patches = [
+        %{"op" => "replace", "path" => "/items/0/name", "value" => "updated"},
+        %{"op" => "replace", "path" => "/items/0/value", "value" => 15}
+      ]
+
+      assert_patches_equal(vue.props_diff, expected_patches)
+    end
+
+    test "with id field uses id-based diffing" do
+      assigns = %{
+        items: [
+          %ItemWithId{id: 1, name: "Alice"},
+          %ItemWithId{id: 2, name: "Bob"}
+        ],
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      # Reorder items - with id field, this should be recognized as reordering
+      assigns =
+        assign(assigns, :items, [
+          %ItemWithId{id: 2, name: "Bob"},
+          %ItemWithId{id: 1, name: "Alice"}
+        ])
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.props_diff)
+
+      # With id field, reordering generates remove and add operations
+      # The exact number depends on the diff algorithm implementation
+      remove_ops = Enum.filter(decoded, &(&1["op"] == "remove"))
+      add_ops = Enum.filter(decoded, &(&1["op"] == "add"))
+
+      assert length(remove_ops) > 0
+      assert length(add_ops) > 0
+    end
+  end
+
+  describe "normalize_key/2 - :streams case for %LiveStream{}" do
+    test "LiveStream values are classified as :streams" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+
+      assigns = %{
+        users: stream,
+        regular_prop: "value",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      # Stream should not appear in props
+      assert vue.props == %{"regular_prop" => "value"}
+
+      # Stream should be in streams_diff
+      assert length(vue.streams_diff) > 0
+    end
+
+    test "multiple LiveStreams are all classified correctly" do
+      users_stream = LiveStream.new(:users, make_ref(), [], [])
+      posts_stream = LiveStream.new(:posts, make_ref(), [], [])
+
+      assigns = %{
+        users: users_stream,
+        posts: posts_stream,
+        title: "My Page",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      # Only non-stream prop should appear in props
+      assert vue.props == %{"title" => "My Page"}
+
+      # Both streams should be processed
+      decoded_streams = decode_patch(vue.streams_diff)
+      stream_paths = Enum.map(decoded_streams, & &1["path"]) |> Enum.uniq()
+
+      assert "/users" in stream_paths
+      assert "/posts" in stream_paths
+    end
+  end
+
+  describe "calculate_streams_diff/2 - initial == true branch" do
+    test "initial render resets streams before applying diffs" do
+      users = [
+        %ItemWithId{id: 1, name: "Alice"},
+        %ItemWithId{id: 2, name: "Bob"}
+      ]
+
+      stream = LiveStream.new(:users, make_ref(), users, [])
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should start with replace operation to reset
+      reset_op = Enum.find(decoded, &(&1["path"] == "/users" && &1["op"] == "replace"))
+      assert reset_op
+      assert reset_op["value"] == []
+
+      # Then should have upsert operations for items
+      upsert_ops = Enum.filter(decoded, &(&1["op"] == "upsert"))
+      assert length(upsert_ops) == 2
+    end
+
+    test "initial render with empty stream still resets" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should have at least the reset operation
+      reset_op = Enum.find(decoded, &(&1["path"] == "/users" && &1["op"] == "replace"))
+      assert reset_op
+      assert reset_op["value"] == []
+    end
+
+    test "dead render (not connected) also triggers initial stream reset" do
+      stream = LiveStream.new(:users, make_ref(), [%ItemWithId{id: 1, name: "Alice"}], [])
+
+      # On dead render (no socket or socket not connected), streams should still be processed
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        "v-socket": nil,
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should reset because initial render (dead render is considered initial)
+      reset_op = Enum.find(decoded, &(&1["path"] == "/users" && &1["op"] == "replace"))
+      assert reset_op
+      assert reset_op["value"] == []
+    end
+  end
+
+  describe "calculate_props_diff/2 - edge cases with complex types" do
+    test "changing from map to nil generates replace operation" do
+      assigns = %{
+        data: %{nested: %{value: 123}},
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      assigns = assign(assigns, :data, nil)
+      vue = render_vue_assigns(assigns)
+
+      assert_patches_equal(vue.props_diff, [
+        %{"op" => "replace", "path" => "/data", "value" => nil}
+      ])
+    end
+
+    test "changing from list to empty list generates remove operations" do
+      assigns = %{
+        items: [1, 2, 3],
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      assigns = assign(assigns, :items, [])
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.props_diff)
+
+      # Should have remove operations for all items
+      remove_ops = Enum.filter(decoded, &(&1["op"] == "remove"))
+      assert length(remove_ops) == 3
+
+      # Check paths exist
+      paths = Enum.map(remove_ops, & &1["path"])
+      assert "/items/0" in paths
+      assert "/items/1" in paths
+      assert "/items/2" in paths
+    end
+
+    test "changing from empty list to list with items generates add operations" do
+      assigns = %{
+        items: [],
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      assigns = assign(assigns, :items, [1, 2, 3])
+      vue = render_vue_assigns(assigns)
+
+      expected_patches = [
+        %{"op" => "add", "path" => "/items/0", "value" => 1},
+        %{"op" => "add", "path" => "/items/1", "value" => 2},
+        %{"op" => "add", "path" => "/items/2", "value" => 3}
+      ]
+
+      assert_patches_equal(vue.props_diff, expected_patches)
+    end
+
+    test "deeply nested changes are detected correctly" do
+      assigns = %{
+        data: %{
+          level1: %{
+            level2: %{
+              level3: %{
+                value: "old"
+              }
+            }
+          }
+        },
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      assigns =
+        assign(assigns, :data, %{
+          level1: %{
+            level2: %{
+              level3: %{
+                value: "new"
+              }
+            }
+          }
+        })
+
+      vue = render_vue_assigns(assigns)
+
+      assert_patches_equal(vue.props_diff, [
+        %{"op" => "replace", "path" => "/data/level1/level2/level3/value", "value" => "new"}
+      ])
+    end
+  end
+
+  describe "prepare_diff/1 - both variants" do
+    test "prepare_diff with value creates 3-element list" do
+      assigns = %{
+        name: "John",
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      assigns = assign(assigns, :name, "Jane")
+      vue = render_vue_assigns(assigns)
+
+      # Check that patches are compressed to 3-element lists
+      assert Enum.all?(vue.props_diff, fn
+               [_op, _path, _value] -> true
+               ["test", "", _] -> true
+               _ -> false
+             end)
+    end
+
+    test "prepare_diff without value creates 2-element list" do
+      items = [
+        %ItemWithId{id: 1, name: "Alice"},
+        %ItemWithId{id: 2, name: "Bob"}
+      ]
+
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.delete_item(stream, %ItemWithId{id: 1, name: "Alice"})
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), items, [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      # Remove operations should be 2-element lists (no value)
+      remove_ops = Enum.filter(vue.streams_diff, fn
+        ["remove", _path] -> true
+        _ -> false
+      end)
+
+      assert length(remove_ops) > 0
+    end
+  end
+
+  describe "key_changed/2 - both branches" do
+    test "__changed__: nil returns true for all keys" do
+      assigns = %{
+        name: "John",
+        age: 30,
+        active: true,
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      # On initial render, all props should be sent
+      assert vue.props == %{"name" => "John", "age" => 30, "active" => true}
+
+      # props_diff should be empty or only contain test operation
+      decoded = decode_patch(vue.props_diff)
+      assert decoded == []
+    end
+
+    test "__changed__ with changed map filters unchanged keys" do
+      assigns = %{
+        name: "John",
+        age: 30,
+        active: true,
+        "v-component": "TestComponent",
+        __changed__: %{}
+      }
+
+      # Only change name
+      assigns = assign(assigns, :name, "Jane")
+      vue = render_vue_assigns(assigns)
+
+      # Only changed prop should be in props when using diff
+      assert vue.props == %{"name" => "Jane"}
+
+      # And should have corresponding diff
+      decoded = decode_patch(vue.props_diff)
+      assert length(decoded) == 1
+      assert hd(decoded)["path"] == "/name"
+    end
+  end
+
+  describe "get_socket/1 - various assign patterns" do
+    test "returns socket from :socket assign" do
+      socket = %Phoenix.LiveView.Socket{transport_pid: self()}
+
+      assigns = %{
+        socket: socket,
+        name: "test",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      result = LiveVue.get_socket(assigns)
+      assert result == socket
+    end
+
+    test "returns socket from nested [:vue_opts, :socket]" do
+      socket = %Phoenix.LiveView.Socket{transport_pid: self()}
+
+      assigns = %{
+        vue_opts: %{socket: socket},
+        name: "test",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      result = LiveVue.get_socket(assigns)
+      assert result == socket
+    end
+
+    test "prefers [:vue_opts, :socket] over :socket" do
+      socket1 = %Phoenix.LiveView.Socket{transport_pid: self()}
+      socket2 = %Phoenix.LiveView.Socket{transport_pid: self()}
+
+      assigns = %{
+        socket: socket1,
+        vue_opts: %{socket: socket2},
+        name: "test",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      result = LiveVue.get_socket(assigns)
+      assert result == socket2
+    end
+
+    test "returns nil when no socket present" do
+      assigns = %{
+        name: "test",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      result = LiveVue.get_socket(assigns)
+      assert result == nil
+    end
+
+    test "returns nil when socket is not a Socket struct" do
+      assigns = %{
+        socket: "not a socket",
+        "v-component": "TestComponent",
+        __changed__: nil
+      }
+
+      result = LiveVue.get_socket(assigns)
+      assert result == nil
+    end
+  end
+
+  describe "LiveStream edge cases" do
+    test "stream with update_only flag creates replace operation" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.insert_item(stream, %ItemWithId{id: 1, name: "Updated"}, -1, nil, true)
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), [], [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should have replace operation instead of upsert
+      replace_op = Enum.find(decoded, &(&1["op"] == "replace" && String.contains?(&1["path"], "$$")))
+      assert replace_op
+      assert replace_op["value"]["name"] == "Updated"
+    end
+
+    test "stream insert at position 0 uses 0 in path" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.insert_item(stream, %ItemWithId{id: 1, name: "First"}, 0, nil, false)
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), [], [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should use 0 in path for position 0
+      upsert_op = Enum.find(decoded, &(&1["op"] == "upsert"))
+      assert upsert_op
+      assert upsert_op["path"] == "/users/0"
+    end
+
+    test "stream insert at position -1 uses - in path" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.insert_item(stream, %ItemWithId{id: 1, name: "Last"}, -1, nil, false)
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), [], [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should use - in path for position -1
+      upsert_op = Enum.find(decoded, &(&1["op"] == "upsert"))
+      assert upsert_op
+      assert upsert_op["path"] == "/users/-"
+    end
+
+    test "stream with limit adds limit operation" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.insert_item(stream, %ItemWithId{id: 1, name: "User"}, -1, 5, false)
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), [], [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should have limit operation
+      limit_op = Enum.find(decoded, &(&1["op"] == "limit"))
+      assert limit_op
+      assert limit_op["path"] == "/users"
+      assert limit_op["value"] == 5
+    end
+
+    test "stream without limit does not add limit operation" do
+      stream = LiveStream.new(:users, make_ref(), [], [])
+      stream = LiveStream.insert_item(stream, %ItemWithId{id: 1, name: "User"}, -1, nil, false)
+
+      assigns = %{
+        users: stream,
+        "v-component": "TestComponent",
+        __changed__: %{users: LiveStream.new(:users, make_ref(), [], [])}
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      decoded = decode_patch(vue.streams_diff)
+
+      # Should not have limit operation
+      limit_op = Enum.find(decoded, &(&1["op"] == "limit"))
+      assert limit_op == nil
+    end
+  end
+
+  describe "normalize_key edge cases" do
+    test "special keys are not treated as props" do
+      assigns = %{
+        id: "custom-id",
+        class: "custom-class",
+        "v-ssr": false,
+        "v-diff": false,
+        "v-component": "TestComponent",
+        "v-socket": nil,
+        regular_prop: "value",
+        __changed__: nil
+      }
+
+      vue = render_vue_assigns(assigns)
+
+      # Only regular_prop should be in props
+      assert vue.props == %{"regular_prop" => "value"}
+
+      # Special keys should be used for their specific purposes
+      assert vue.id == "custom-id"
+      assert vue.class == "custom-class"
+      assert vue.ssr == false
+      assert vue.use_diff == false
+    end
+  end
+end

--- a/test/live_vue_ssr_nodejs_test.exs
+++ b/test/live_vue_ssr_nodejs_test.exs
@@ -1,0 +1,86 @@
+defmodule LiveVue.SSR.NodeJSTest do
+  use ExUnit.Case
+
+  alias LiveVue.SSR.NodeJS, as: NodeJSRenderer
+
+  @moduletag :nodejs_ssr
+
+  # Path to our test support directory
+  @test_support_path Path.expand("support", __DIR__)
+  # Just the filename - NodeJS.Supervisor resolves relative to its path
+  @test_server_filename "ssr_test_server.mjs"
+
+  describe "render/3 with NodeJS.Supervisor running" do
+    setup do
+      # Start NodeJS.Supervisor for this test (from the nodejs package)
+      # The path should be the directory containing our test server
+      start_supervised!({NodeJS.Supervisor, [path: @test_support_path, pool_size: 1]})
+
+      # Configure to use our test server - just the filename since NodeJS resolves relative to path
+      Application.put_env(:live_vue, :ssr_filepath, @test_server_filename)
+
+      on_exit(fn ->
+        Application.delete_env(:live_vue, :ssr_filepath)
+      end)
+
+      :ok
+    end
+
+    test "renders component and returns HTML" do
+      result = NodeJSRenderer.render("TestComponent", %{"count" => 42}, %{})
+
+      assert is_binary(result)
+      assert result =~ "SSR Rendered: TestComponent"
+      assert result =~ "TestComponent"
+    end
+
+    test "passes props to the render function" do
+      result = NodeJSRenderer.render("MyComponent", %{"name" => "John", "age" => 30}, %{})
+
+      assert result =~ "John"
+      assert result =~ "30"
+    end
+
+    test "passes slots to the render function" do
+      result = NodeJSRenderer.render("SlotComponent", %{}, %{"default" => "<p>Content</p>"})
+
+      assert result =~ "Content"
+    end
+
+    test "handles preload links delimiter" do
+      result = NodeJSRenderer.render("WithPreloadLinks", %{}, %{})
+
+      assert result =~ "<link"
+      assert result =~ "<!-- preload -->"
+    end
+  end
+
+  describe "render/3 without NodeJS.Supervisor" do
+    test "raises NotConfigured when NodeJS.Supervisor is not running" do
+      # Make sure no supervisor is running
+      # Configure to use our test server filename
+      Application.put_env(:live_vue, :ssr_filepath, @test_server_filename)
+
+      on_exit(fn ->
+        Application.delete_env(:live_vue, :ssr_filepath)
+      end)
+
+      assert_raise LiveVue.SSR.NotConfigured,
+                   ~r/NodeJS is not configured/,
+                   fn ->
+                     NodeJSRenderer.render("TestComponent", %{}, %{})
+                   end
+    end
+  end
+
+  describe "server_path/0" do
+    test "returns the priv directory path for the current application" do
+      # server_path/0 uses :application.get_application() which returns :undefined
+      # when called outside of application context (like in tests)
+      # This is expected behavior - it's designed to be called from within an application
+      assert_raise MatchError, fn ->
+        NodeJSRenderer.server_path()
+      end
+    end
+  end
+end

--- a/test/live_vue_ssr_test.exs
+++ b/test/live_vue_ssr_test.exs
@@ -1,0 +1,211 @@
+defmodule LiveVue.SSRTest do
+  use ExUnit.Case
+
+  alias LiveVue.SSR
+
+  defmodule MockSSRRenderer do
+    @moduledoc false
+    @behaviour LiveVue.SSR
+
+    @impl true
+    def render("WithPreload", _props, _slots) do
+      "<link rel=\"preload\" /><!-- preload --><div>Component HTML</div>"
+    end
+
+    @impl true
+    def render("NoPreload", _props, _slots) do
+      "<div>Just HTML</div>"
+    end
+
+    @impl true
+    def render("MapResponse", _props, _slots) do
+      %{preloadLinks: "<link rel=\"stylesheet\" />", html: "<div>Direct map</div>"}
+    end
+
+    @impl true
+    def render("Echo", props, slots) do
+      props_str = Jason.encode!(props)
+      slots_str = Jason.encode!(slots)
+      "<div>Props: #{props_str}, Slots: #{slots_str}</div>"
+    end
+  end
+
+  setup do
+    # Clean up config after each test
+    on_exit(fn ->
+      Application.delete_env(:live_vue, :ssr_module)
+    end)
+
+    :ok
+  end
+
+  describe "render/3 when ssr_module is not configured" do
+    test "returns empty map with empty strings" do
+      Application.delete_env(:live_vue, :ssr_module)
+
+      result = SSR.render("AnyComponent", %{}, %{})
+
+      assert result == %{preloadLinks: "", html: ""}
+    end
+
+    test "ignores props and slots when not configured" do
+      Application.delete_env(:live_vue, :ssr_module)
+
+      result = SSR.render("Component", %{"key" => "value"}, %{"slot" => "content"})
+
+      assert result == %{preloadLinks: "", html: ""}
+    end
+  end
+
+  describe "render/3 when ssr_module is configured" do
+    setup do
+      Application.put_env(:live_vue, :ssr_module, MockSSRRenderer)
+      :ok
+    end
+
+    test "splits response on <!-- preload --> delimiter" do
+      result = SSR.render("WithPreload", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "<link rel=\"preload\" />",
+               html: "<div>Component HTML</div>"
+             }
+    end
+
+    test "handles response without preload delimiter" do
+      result = SSR.render("NoPreload", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "",
+               html: "<div>Just HTML</div>"
+             }
+    end
+
+    test "passes through map response directly" do
+      result = SSR.render("MapResponse", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "<link rel=\"stylesheet\" />",
+               html: "<div>Direct map</div>"
+             }
+    end
+
+    test "forwards component name, props, and slots to renderer" do
+      props = %{"count" => 42, "title" => "Test"}
+      slots = %{"default" => "<span>Content</span>"}
+
+      result = SSR.render("Echo", props, slots)
+
+      assert result.html =~ "\"count\":42"
+      assert result.html =~ "\"title\":\"Test\""
+      assert result.html =~ "\"default\":\"<span>Content</span>\""
+    end
+  end
+
+  describe "render/3 telemetry" do
+    setup do
+      Application.put_env(:live_vue, :ssr_module, MockSSRRenderer)
+
+      # Attach telemetry handler
+      handler_id = :telemetry_test_handler
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:live_vue, :ssr, :start],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn ->
+        :telemetry.detach(handler_id)
+      end)
+
+      :ok
+    end
+
+    test "emits telemetry span with correct metadata" do
+      props = %{"key" => "value"}
+      slots = %{"header" => "Header content"}
+
+      SSR.render("NoPreload", props, slots)
+
+      assert_receive {:telemetry_event, [:live_vue, :ssr, :start], _measurements, metadata}
+
+      assert metadata.component == "NoPreload"
+      assert metadata.props == %{"key" => "value"}
+      assert metadata.slots == %{"header" => "Header content"}
+    end
+
+    test "emits telemetry for each render call" do
+      SSR.render("WithPreload", %{}, %{})
+      SSR.render("NoPreload", %{}, %{})
+
+      assert_receive {:telemetry_event, [:live_vue, :ssr, :start], _, %{component: "WithPreload"}}
+      assert_receive {:telemetry_event, [:live_vue, :ssr, :start], _, %{component: "NoPreload"}}
+    end
+  end
+
+  describe "render/3 edge cases" do
+    defmodule EdgeCaseRenderer do
+      @behaviour LiveVue.SSR
+
+      @impl true
+      def render("MultipleDelimiters", _props, _slots) do
+        "<link /><!-- preload --><div><!-- preload -->Another one</div>"
+      end
+
+      @impl true
+      def render("EmptyPreload", _props, _slots) do
+        "<!-- preload --><div>No preload links</div>"
+      end
+
+      @impl true
+      def render("EmptyHTML", _props, _slots) do
+        "<link /><!-- preload -->"
+      end
+    end
+
+    setup do
+      Application.put_env(:live_vue, :ssr_module, EdgeCaseRenderer)
+      :ok
+    end
+
+    test "splits only on first delimiter with multiple delimiters" do
+      result = SSR.render("MultipleDelimiters", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "<link />",
+               html: "<div><!-- preload -->Another one</div>"
+             }
+    end
+
+    test "handles empty preload section" do
+      result = SSR.render("EmptyPreload", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "",
+               html: "<div>No preload links</div>"
+             }
+    end
+
+    test "handles empty HTML section" do
+      result = SSR.render("EmptyHTML", %{}, %{})
+
+      assert result == %{
+               preloadLinks: "<link />",
+               html: ""
+             }
+    end
+  end
+
+  describe "LiveVue.SSR.NotConfigured exception" do
+    test "can be raised with a message" do
+      assert_raise SSR.NotConfigured, "SSR is not configured", fn ->
+        raise SSR.NotConfigured, message: "SSR is not configured"
+      end
+    end
+  end
+end

--- a/test/live_vue_test.exs
+++ b/test/live_vue_test.exs
@@ -230,4 +230,40 @@ defmodule LiveVueTest do
       assert vue.slots == %{}
     end
   end
+
+  describe "edge cases" do
+    def edge_case_component(assigns) do
+      ~H"""
+      <.vue name="John" v-component="MyComponent" />
+      """
+    end
+
+    test "raises ArgumentError with invalid option key" do
+      html = render_component(&edge_case_component/1)
+
+      assert_raise ArgumentError,
+                   "invalid keyword option for get_vue/2: foo",
+                   fn ->
+                     Test.get_vue(html, foo: "bar")
+                   end
+    end
+
+    test "raises error when no Vue components found" do
+      html = "<div>No Vue components here</div>"
+
+      assert_raise RuntimeError,
+                   "No Vue components found in the rendered HTML",
+                   fn ->
+                     Test.get_vue(html)
+                   end
+    end
+
+    test "handles missing attributes gracefully" do
+      html = render_component(&edge_case_component/1)
+      vue = Test.get_vue(html)
+
+      # Components without class attribute should return nil or empty string
+      assert vue.class in [nil, ""]
+    end
+  end
 end

--- a/test/support/ssr_test_server.mjs
+++ b/test/support/ssr_test_server.mjs
@@ -1,0 +1,18 @@
+// Test SSR server for NodeJS SSR tests
+// This is a minimal implementation that echoes back the component info
+
+export function render(name, props, slots) {
+  // Simulate the real SSR behavior
+  if (name === "WithPreloadLinks") {
+    return `<link rel="stylesheet" href="/app.css" /><!-- preload --><div class="ssr-rendered">${name}</div>`;
+  }
+
+  if (name === "Error") {
+    throw new Error("Intentional test error");
+  }
+
+  // Default: return simple HTML
+  const propsStr = JSON.stringify(props);
+  const slotsStr = JSON.stringify(slots);
+  return `<div data-component="${name}" data-props="${propsStr.replace(/"/g, '&quot;')}" data-slots="${slotsStr.replace(/"/g, '&quot;')}">SSR Rendered: ${name}</div>`;
+}


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for low-coverage modules to improve test coverage across the codebase. Tests cover SSR module functionality, internal utility functions, and NodeJS integration.

## Test Plan

- Run `mix test` to verify all tests pass
- Run `mix test --include nodejs_ssr` to specifically test NodeJS SSR integration
- Coverage should increase for:
  - `lib/live_vue/ssr.ex`
  - `lib/live_vue/ssr/node_js.ex`
  - `lib/live_vue/test.ex`
  - `lib/live_vue.ex` (internal functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)