### PR TITLE
fix: exclude test files from hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -113,7 +113,8 @@ defmodule LiveVue.MixProject do
         Changelog: @repo_url <> "/blob/master/CHANGELOG.md",
         GitHub: @repo_url
       },
-      files: ~w(assets lib mix.exs package.json .formatter.exs LICENSE.md README.md CHANGELOG.md usage-rules.md)
+      files: ~w(assets lib mix.exs package.json .formatter.exs LICENSE.md README.md CHANGELOG.md usage-rules.md),
+      exclude_patterns: [~r/\.test\.ts$/]
     ]
   end
 


### PR DESCRIPTION
## Summary

- Exclude `*.test.ts` files from hex package using `exclude_patterns` regex
- Reduces package size by ~127KB of unnecessary test files

## Test plan

- [x] Verified with `mix hex.build --unpack` that test files are no longer included

🤖 Generated with [Claude Code](https://claude.com/claude-code)