### PR TITLE
fix: use explicit app name in server_path() to fix production releases

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -357,10 +357,12 @@ For production deployments, you'll need Node.js 19+ and proper configuration:
 
 ```elixir
 children = [
-  {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(), pool_size: 4]},
+  {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:your_app), pool_size: 4]},
   # ... other children
 ]
 ```
+
+Replace `:your_app` with your application's atom name (found in `mix.exs` under `project/0`).
 
 3. **Build server bundle** as part of your deployment:
 

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -308,9 +308,20 @@ node --version  # Should be 19+
 ```elixir
 # application.ex
 children = [
-  {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(), pool_size: 4]},
+  {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:your_app), pool_size: 4]},
   # ... other children
 ]
+```
+
+Replace `:your_app` with your application's atom name.
+
+**Getting `:undefined` or `MatchError` from `server_path()`?**
+
+This happens when using `server_path/0` (without arguments) in production releases. The function relies on `:application.get_application/0` which may not work correctly during supervisor startup in OTP releases.
+
+**Solution**: Always use `server_path/1` with your explicit app name:
+```elixir
+{NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:my_app), pool_size: 4]}
 ```
 
 **Verify server bundle exists:**

--- a/lib/live_vue/ssr/node_js.ex
+++ b/lib/live_vue/ssr/node_js.ex
@@ -21,15 +21,48 @@ defmodule LiveVue.SSR.NodeJS do
       :exit, {:noproc, _} ->
         message = """
         NodeJS is not configured. Please add the following to your application.ex:
-        {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(), pool_size: 4]},
+        {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:your_app), pool_size: 4]},
+
+        Replace :your_app with your application's atom name (e.g., :my_app).
         """
 
         raise %LiveVue.SSR.NotConfigured{message: message}
     end
   end
 
+  @doc """
+  Returns the path to the priv directory for NodeJS.Supervisor.
+
+  ## Usage
+
+  In your `application.ex`, pass your app's atom name explicitly:
+
+      {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:my_app), pool_size: 4]}
+
+  The zero-argument version attempts to auto-detect the calling application,
+  but this can fail in production releases where the process context may not
+  be associated with an application during supervisor startup. For reliable
+  production deployments, always use `server_path/1` with your app name.
+  """
+  def server_path(app) when is_atom(app) do
+    Application.app_dir(app, "/priv")
+  end
+
+  @doc """
+  Auto-detects the calling application and returns its priv directory path.
+
+  > #### Warning {: .warning}
+  >
+  > This function can fail in production releases. Use `server_path/1` instead.
+
+  This function uses `:application.get_application/0` which relies on the calling
+  process belonging to an application. In production OTP releases, this may return
+  `:undefined` during supervisor startup, causing a `MatchError`.
+
+  See `server_path/1` for a more reliable alternative.
+  """
   def server_path do
-    {:ok, path} = :application.get_application()
-    Application.app_dir(path, "/priv")
+    {:ok, app} = :application.get_application()
+    Application.app_dir(app, "/priv")
   end
 end

--- a/lib/mix/tasks/live_vue.install.ex
+++ b/lib/mix/tasks/live_vue.install.ex
@@ -320,7 +320,7 @@ defmodule Mix.Tasks.LiveVue.Install do
     end
 
     # Setup SSR for production in application.ex
-    defp setup_ssr_for_production(igniter, _app_name) do
+    defp setup_ssr_for_production(igniter, app_name) do
       app_module = igniter |> Igniter.Project.Application.app_name() |> to_string()
       app_file = "lib/#{Macro.underscore(app_module)}/application.ex"
 
@@ -332,7 +332,7 @@ defmodule Mix.Tasks.LiveVue.Install do
             String.replace(
               content,
               ~r/(children = \[\s*\n)/,
-              "\\1      {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(), pool_size: 4]},\n"
+              "\\1      {NodeJS.Supervisor, [path: LiveVue.SSR.NodeJS.server_path(:#{app_name}), pool_size: 4]},\n"
             )
           else
             content

--- a/test/live_vue_ssr_nodejs_test.exs
+++ b/test/live_vue_ssr_nodejs_test.exs
@@ -74,13 +74,32 @@ defmodule LiveVue.SSR.NodeJSTest do
   end
 
   describe "server_path/0" do
-    test "returns the priv directory path for the current application" do
+    test "raises MatchError when called outside application context" do
       # server_path/0 uses :application.get_application() which returns :undefined
       # when called outside of application context (like in tests)
-      # This is expected behavior - it's designed to be called from within an application
+      # This is expected behavior - use server_path/1 instead for reliable paths
       assert_raise MatchError, fn ->
         NodeJSRenderer.server_path()
       end
+    end
+  end
+
+  describe "server_path/1" do
+    test "returns the priv directory path for the given application" do
+      # server_path/1 takes an explicit app name and returns its priv directory
+      path = NodeJSRenderer.server_path(:live_vue)
+
+      assert is_binary(path)
+      assert String.ends_with?(path, "/priv")
+      assert String.contains?(path, "live_vue")
+    end
+
+    test "works with any valid application atom" do
+      # Should work with any loaded application
+      path = NodeJSRenderer.server_path(:elixir)
+
+      assert is_binary(path)
+      assert String.ends_with?(path, "/priv")
     end
   end
 end

--- a/test/mix/tasks/live_vue.install_test.exs
+++ b/test/mix/tasks/live_vue.install_test.exs
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.LiveVue.InstallTest do
       # Check that SSR production setup was applied
       app_file = project.rewrite.sources["lib/test/application.ex"]
       assert app_file.content =~ ~r/NodeJS\.Supervisor/
-      assert app_file.content =~ ~r/path: LiveVue\.SSR\.NodeJS\.server_path\(\)/
+      assert app_file.content =~ ~r/path: LiveVue\.SSR\.NodeJS\.server_path\(:test\)/
       assert app_file.content =~ ~r/pool_size: 4/
 
       # Check that AGENTS.md was updated with usage rules


### PR DESCRIPTION
## Summary

Fixes production deployment crashes when `:application.get_application/0` returns `:undefined` during OTP release supervisor startup. The new `server_path/1` function takes an explicit app name for reliable path resolution.

Addresses issue reported in https://github.com/Valian/live_vue/discussions/114

## Changes

- Added `server_path/1` that accepts an explicit app name atom
- Updated docs and installer to use `server_path(:my_app)` instead of `server_path()`
- Added troubleshooting section for this specific error
- Kept `server_path/0` for backwards compatibility with deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)