### PR TITLE
Fix crash on compound Ecto types in form error translation

### DIFF
--- a/lib/live_vue/encoder.ex
+++ b/lib/live_vue/encoder.ex
@@ -319,7 +319,10 @@ defimpl LiveVue.Encoder, for: Phoenix.HTML.Form do
 
       true ->
         Enum.reduce(opts, msg, fn {key, value}, acc ->
-          String.replace(acc, "%{#{key}}", value |> List.wrap() |> Enum.map_join(", ", &to_string/1))
+          String.replace(acc, "%{#{key}}", value |> List.wrap() |> Enum.map_join(", ", fn
+            v when is_binary(v) or is_atom(v) or is_number(v) -> to_string(v)
+            v -> inspect(v)
+          end))
         end)
     end
   end

--- a/test/live_vue_encoder_test.exs
+++ b/test/live_vue_encoder_test.exs
@@ -547,6 +547,33 @@ defmodule LiveVue.EncoderTest do
     end
   end
 
+  describe "form error translation with compound types" do
+    test "translates errors with compound type opts without crashing" do
+      # Ecto compound types like {:array, :map} end up in error opts as tuples,
+      # which aren't handled by to_string/1
+      form = %Phoenix.HTML.Form{
+        source: nil,
+        impl: nil,
+        id: "test",
+        name: "test",
+        data: %{},
+        action: nil,
+        hidden: [],
+        params: %{},
+        errors: [
+          items: {"is invalid", [type: {:array, :map}, validation: :cast]},
+          tags: {"is invalid", [type: {:array, :integer}, validation: :cast]}
+        ],
+        options: []
+      }
+
+      encoded = Encoder.encode(form)
+
+      assert encoded.errors[:items] == ["is invalid"]
+      assert encoded.errors[:tags] == ["is invalid"]
+    end
+  end
+
   describe "Phoenix.LiveView.AsyncResult" do
     test "encodes AsyncResult in loading state" do
       async_result = AsyncResult.loading()


### PR DESCRIPTION
## Summary
- `to_string/1` crashes on tuples like `{:array, :map}` that appear in Ecto validation opts for compound types (e.g. `embeds_many`, `{:array, :integer}` fields)
- Falls back to `inspect/1` for non-stringable values in the `translate_error/1` fallback branch (no Gettext backend)
- Adds regression test with compound type error opts

## Test plan
- [x] New test reproduces the crash without the fix (`String.Chars.impl_for!/1` error at `encoder.ex:322`)
- [x] New test passes with the fix
- [x] All 38 encoder tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)