### PR TITLE
fix: useLiveUpload rebuilds input when uploadConfig.ref changes

### DIFF
--- a/assets/use.ts
+++ b/assets/use.ts
@@ -1,4 +1,4 @@
-import { inject, onMounted, onUnmounted, ref, computed, watchEffect, toValue, type ComputedRef, type Ref } from "vue"
+import { inject, onMounted, onUnmounted, ref, computed, watch, watchEffect, toValue, type ComputedRef, type Ref } from "vue"
 import type { MaybeRefOrGetter } from "vue"
 import type { LiveHook, UploadConfig, UploadEntry, UploadOptions } from "./types.js"
 
@@ -109,74 +109,84 @@ export const useLiveUpload = (
   const live = useLiveVue()
   const inputEl = ref<HTMLInputElement | null>(null)
 
-  // Create and manage the hidden file input element with Phoenix upload attributes
-  onMounted(() => {
-    if (!inputEl.value) {
-      // Create a form to wrap the input, with phx-change="validate"
-      const uploadConfigValue = toValue(uploadConfig)
-      const form = document.createElement("form")
-      if (options.changeEvent) form.setAttribute("phx-change", options.changeEvent)
-      form.setAttribute("phx-submit", options.submitEvent)
-      form.style.display = "none"
+  const removeInput = () => {
+    if (!inputEl.value) return
+    ;(inputEl.value as any).__unwatchConfig?.()
+    inputEl.value.form?.remove()
+    inputEl.value.remove()
+    inputEl.value = null
+  }
 
-      const input = document.createElement("input")
-      input.type = "file"
-      input.id = uploadConfigValue.ref
-      input.name = uploadConfigValue.name
+  const createInput = (config: UploadConfig) => {
+    const form = document.createElement("form")
+    if (options.changeEvent) form.setAttribute("phx-change", options.changeEvent)
+    form.setAttribute("phx-submit", options.submitEvent)
+    form.style.display = "none"
 
-      // Phoenix LiveView upload attributes - these are critical for Phoenix to find and manage the input
-      input.setAttribute("data-phx-hook", "Phoenix.LiveFileUpload")
-      input.setAttribute("data-phx-update", "ignore")
-      input.setAttribute("data-phx-upload-ref", uploadConfigValue.ref)
-      form.appendChild(input)
+    const input = document.createElement("input")
+    input.type = "file"
+    input.id = config.ref
+    input.name = config.name
 
-      // Set accept attribute if specified
-      if (uploadConfigValue.accept && typeof uploadConfigValue.accept === "string") {
-        input.accept = uploadConfigValue.accept
-      }
+    // Phoenix LiveView upload attributes - these are critical for Phoenix to find and manage the input
+    input.setAttribute("data-phx-hook", "Phoenix.LiveFileUpload")
+    input.setAttribute("data-phx-update", "ignore")
+    input.setAttribute("data-phx-upload-ref", config.ref)
+    form.appendChild(input)
 
-      // Set auto_upload attribute if specified
-      if (uploadConfigValue.auto_upload) {
-        input.setAttribute("data-phx-auto-upload", "true")
-      }
-
-      // Set multiple attribute based on max_entries
-      if (uploadConfigValue.max_entries > 1) {
-        input.multiple = true
-      }
-
-      // Update entry refs attributes based on current entries
-      const updateEntryRefs = () => {
-        const config = toValue(uploadConfig)
-        const joinEntries = (entries: UploadEntry[]) => entries.map(e => e.ref).join(",")
-
-        input.setAttribute("data-phx-active-refs", joinEntries(config.entries))
-        input.setAttribute("data-phx-done-refs", joinEntries(config.entries.filter(e => e.done)))
-        input.setAttribute("data-phx-preflighted-refs", joinEntries(config.entries.filter(e => e.preflighted)))
-      }
-
-      const unwatchConfig = watchEffect(() => updateEntryRefs())
-
-      // Store unwatch function for cleanup
-      ;(input as any).__unwatchConfig = unwatchConfig
-
-      // Append to the LiveView element so Phoenix can find it
-      // Phoenix searches for upload inputs within the LiveView element
-      live.el.appendChild(form)
-      inputEl.value = input
+    // Set accept attribute if specified
+    if (config.accept && typeof config.accept === "string") {
+      input.accept = config.accept
     }
+
+    // Set auto_upload attribute if specified
+    if (config.auto_upload) {
+      input.setAttribute("data-phx-auto-upload", "true")
+    }
+
+    // Set multiple attribute based on max_entries
+    if (config.max_entries > 1) {
+      input.multiple = true
+    }
+
+    // Update entry refs attributes based on current entries
+    const unwatchConfig = watchEffect(() => {
+      const current = toValue(uploadConfig)
+      const joinEntries = (entries: UploadEntry[]) => entries.map(e => e.ref).join(",")
+
+      input.setAttribute("data-phx-active-refs", joinEntries(current.entries))
+      input.setAttribute("data-phx-done-refs", joinEntries(current.entries.filter(e => e.done)))
+      input.setAttribute("data-phx-preflighted-refs", joinEntries(current.entries.filter(e => e.preflighted)))
+    })
+
+    // Store unwatch function for cleanup
+    ;(input as any).__unwatchConfig = unwatchConfig
+
+    // Append to the LiveView element so Phoenix can find it
+    live.el.appendChild(form)
+    inputEl.value = input
+  }
+
+  // Create hidden input on mount
+  onMounted(() => {
+    if (!inputEl.value) createInput(toValue(uploadConfig))
   })
+
+  // Rebuild hidden input when upload config identity changes
+  watch(
+    () => {
+      const c = toValue(uploadConfig)
+      return `${c.ref}|${c.name}|${c.accept}|${c.auto_upload}|${c.max_entries}`
+    },
+    (next, prev) => {
+      if (!inputEl.value || next === prev) return
+      removeInput()
+      createInput(toValue(uploadConfig))
+    }
+  )
 
   // Clean up the input element when component unmounts
-  onUnmounted(() => {
-    if (inputEl.value) {
-      // Clean up the watcher
-      ;(inputEl.value as any).__unwatchConfig?.()
-      inputEl.value.form?.remove()
-      inputEl.value.remove()
-      inputEl.value = null
-    }
-  })
+  onUnmounted(removeInput)
 
   // Reactive entries from the upload config
   const entries = computed(() => {

--- a/assets/useLiveUpload.test.ts
+++ b/assets/useLiveUpload.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { ref, nextTick } from "vue"
+
+// We need real Vue reactivity (ref, watch, watchEffect, computed, nextTick) but must
+// mock inject (to provide a fake LiveHook), onMounted (to fire immediately), and
+// onUnmounted (to capture the cleanup callback so we can invoke it manually).
+const mockLiveRef = { value: null as any }
+let unmountCallbacks: Array<() => void> = []
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual("vue")
+  return {
+    ...actual,
+    inject: vi.fn(() => mockLiveRef.value),
+    provide: vi.fn(),
+    onMounted: vi.fn((fn: () => void) => fn()), // execute immediately
+    onUnmounted: vi.fn((fn: () => void) => {
+      unmountCallbacks.push(fn)
+    }),
+  }
+})
+
+import { useLiveUpload } from "./use"
+import type { UploadConfig, UploadOptions } from "./types"
+
+function createUploadConfig(overrides: Partial<UploadConfig> = {}): UploadConfig {
+  return {
+    ref: "phx-old",
+    name: "avatar",
+    accept: ".png,.jpg",
+    max_entries: 1,
+    auto_upload: false,
+    entries: [],
+    errors: [],
+    ...overrides,
+  }
+}
+
+const defaultOptions: UploadOptions = {
+  changeEvent: "validate",
+  submitEvent: "save",
+}
+
+describe("useLiveUpload", () => {
+  let mockEl: HTMLElement
+
+  beforeEach(() => {
+    unmountCallbacks = []
+    mockEl = document.createElement("div")
+    document.body.appendChild(mockEl)
+
+    mockLiveRef.value = {
+      handleEvent: vi.fn().mockReturnValue("cb-id"),
+      removeHandleEvent: vi.fn(),
+      pushEvent: vi.fn(),
+      pushEventTo: vi.fn(),
+      el: mockEl,
+      liveSocket: {
+        pushHistoryPatch: vi.fn(),
+        historyRedirect: vi.fn(),
+        execJS: vi.fn(),
+      },
+    }
+  })
+
+  function triggerUnmount() {
+    unmountCallbacks.forEach(fn => fn())
+    unmountCallbacks = []
+  }
+
+  it("should create hidden input on mount with correct attributes", () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-abc" }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value).not.toBeNull()
+    const input = result.inputEl.value as HTMLInputElement
+    expect(input.getAttribute("data-phx-upload-ref")).toBe("phx-abc")
+    expect(input.id).toBe("phx-abc")
+    expect(input.name).toBe("avatar")
+    expect(input.accept).toBe(".png,.jpg")
+    expect(input.multiple).toBe(false)
+
+    const form = input.form!
+    expect(form.getAttribute("phx-change")).toBe("validate")
+    expect(form.getAttribute("phx-submit")).toBe("save")
+    expect(form.style.display).toBe("none")
+
+    triggerUnmount()
+  })
+
+  it("should set multiple when max_entries > 1", () => {
+    const configRef = ref(createUploadConfig({ max_entries: 5 }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value!.multiple).toBe(true)
+
+    triggerUnmount()
+  })
+
+  it("should set data-phx-auto-upload when auto_upload is true", () => {
+    const configRef = ref(createUploadConfig({ auto_upload: true }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value!.getAttribute("data-phx-auto-upload")).toBe("true")
+
+    triggerUnmount()
+  })
+
+  it("should rebuild hidden input when uploadConfig.ref changes", async () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-old" }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    const oldInput = result.inputEl.value as HTMLInputElement
+    expect(oldInput.getAttribute("data-phx-upload-ref")).toBe("phx-old")
+
+    // Update the ref — simulates server sending a new upload config
+    configRef.value = createUploadConfig({ ref: "phx-new" })
+    await nextTick()
+
+    const newInput = result.inputEl.value as HTMLInputElement
+    expect(newInput).not.toBeNull()
+    expect(newInput.getAttribute("data-phx-upload-ref")).toBe("phx-new")
+    expect(newInput.id).toBe("phx-new")
+
+    // Old input should be removed from the DOM
+    expect(oldInput.parentElement).toBeNull()
+    expect(mockEl.querySelector('[data-phx-upload-ref="phx-old"]')).toBeNull()
+
+    triggerUnmount()
+  })
+
+  it("should rebuild hidden input when accept changes", async () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-1", accept: ".png" }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value!.accept).toBe(".png")
+
+    configRef.value = createUploadConfig({ ref: "phx-1", accept: ".gif,.webp" })
+    await nextTick()
+
+    expect(result.inputEl.value!.accept).toBe(".gif,.webp")
+
+    triggerUnmount()
+  })
+
+  it("should rebuild hidden input when max_entries changes", async () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-1", max_entries: 1 }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value!.multiple).toBe(false)
+
+    configRef.value = createUploadConfig({ ref: "phx-1", max_entries: 3 })
+    await nextTick()
+
+    expect(result.inputEl.value!.multiple).toBe(true)
+
+    triggerUnmount()
+  })
+
+  it("should not rebuild when only entries change", async () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-1" }))
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    const originalInput = result.inputEl.value
+
+    configRef.value = {
+      ...createUploadConfig({ ref: "phx-1" }),
+      entries: [{ ref: "0", client_name: "photo.png", client_size: 1024, client_type: "image/png", progress: 0, done: false, preflighted: false, errors: [] }],
+    }
+    await nextTick()
+
+    // Same input element should be reused (not rebuilt)
+    expect(result.inputEl.value).toBe(originalInput)
+
+    triggerUnmount()
+  })
+
+  it("should clean up old input when rebuilding", async () => {
+    const configRef = ref(createUploadConfig({ ref: "phx-old" }))
+    useLiveUpload(configRef, defaultOptions)
+
+    expect(mockEl.querySelectorAll("form").length).toBe(1)
+
+    configRef.value = createUploadConfig({ ref: "phx-new" })
+    await nextTick()
+
+    // Still only one form after rebuild
+    expect(mockEl.querySelectorAll("form").length).toBe(1)
+    expect(mockEl.querySelector('[data-phx-upload-ref="phx-new"]')).not.toBeNull()
+
+    triggerUnmount()
+  })
+
+  it("should clean up input on unmount", () => {
+    const configRef = ref(createUploadConfig())
+    const result = useLiveUpload(configRef, defaultOptions)
+
+    expect(result.inputEl.value).not.toBeNull()
+    expect(mockEl.querySelectorAll("form").length).toBe(1)
+
+    triggerUnmount()
+
+    expect(result.inputEl.value).toBeNull()
+    expect(mockEl.querySelectorAll("form").length).toBe(0)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,11 +48,11 @@
       "dev": true
     },
     "deps/phoenix_live_view": {
-      "version": "1.1.19",
+      "version": "1.1.24",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "morphdom": "2.7.7"
+        "morphdom": "2.7.8"
       },
       "devDependencies": {
         "@babel/cli": "7.27.2",
@@ -11086,9 +11086,9 @@
       }
     },
     "node_modules/morphdom": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.7.tgz",
-      "integrity": "sha512-04GmsiBcalrSCNmzfo+UjU8tt3PhZJKzcOy+r1FlGA7/zri8wre3I1WkYN9PT3sIeIKfW9bpyElA+VzOg2E24g==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
       "dev": true,
       "license": "MIT"
     },
@@ -20763,9 +20763,9 @@
       }
     },
     "morphdom": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.7.tgz",
-      "integrity": "sha512-04GmsiBcalrSCNmzfo+UjU8tt3PhZJKzcOy+r1FlGA7/zri8wre3I1WkYN9PT3sIeIKfW9bpyElA+VzOg2E24g==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
       "dev": true
     },
     "mri": {
@@ -21593,7 +21593,7 @@
         "jest-environment-jsdom": "^30.0.0",
         "jest-monocart-coverage": "^1.1.1",
         "monocart-reporter": "^2.9.21",
-        "morphdom": "2.7.7",
+        "morphdom": "2.7.8",
         "phoenix": "1.7.21",
         "prettier": "3.5.3",
         "ts-jest": "^29.4.0",


### PR DESCRIPTION
## Summary

- Fixes `useLiveUpload()` keeping stale hidden input when `uploadConfig.ref` changes, causing LiveView `KeyError`
- Extracts input setup/teardown into `createInput()` and `removeInput()` helpers
- Adds `watch()` on config structural identity to detect and rebuild when `ref`, `name`, `accept`, `auto_upload`, or `max_entries` change
- Entry-ref syncing (`watchEffect` for active/done/preflighted) remains and continues working after rebuild

## Testing

- 9 new regression tests covering: basic attributes, multiple/auto-upload flags, rebuild on config changes, no rebuild on entry-only changes, proper DOM cleanup
- All 230 vitest unit tests pass (including new tests)
- 83/84 E2E tests pass (1 pre-existing form reset failure unrelated to uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)