### PR TITLE
feat: add headless Vue components for props propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- Added headless `<.vue>` elements (no `v-component`) that register reactive props under a given `id`, and extended `useLiveVue(elementId)` to look up another component's props by ID — enabling cross-component prop sharing without custom event plumbing ([#135](https://github.com/Valian/live_vue/pull/135))
 - Added `LiveVue.SSR.QuickJS` — embedded SSR via [quickjs_ex](https://hex.pm/packages/quickjs_ex), no Node.js required in production
 - Added `LiveVue.SharedPropsView` — a `~H` sigil override that injects shared props and `v-socket` into all `<.vue>` and LiveVue shortcut component tags at compile time, restoring shared props support with proper LiveView change tracking ([#123](https://github.com/Valian/live_vue/pull/123))
 

--- a/assets/hooks.ts
+++ b/assets/hooks.ts
@@ -1,7 +1,7 @@
 import { createApp, createSSRApp, h, reactive, type App } from "vue"
 import { migrateToLiveVueApp } from "./app.js"
 import type { ComponentMap, LiveVueApp, LiveVueOptions, LiveHook, Hook } from "./types.js"
-import { liveInjectKey } from "./use.js"
+import { liveInjectKey, hooksById } from "./use.js"
 import { mapValues, fromUtf8Base64 } from "./utils.js"
 import { applyPatch, type Operation } from "./jsonPatch.js"
 
@@ -75,17 +75,20 @@ const getProps = (el: HTMLElement, liveSocket: any): Record<string, any> => ({
 
 export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
   async mounted() {
-    const componentName = this.el.getAttribute("data-name") as string
-    const component = await resolve(componentName)
-
-    const makeApp = this.el.getAttribute("data-ssr") === "true" ? createSSRApp : createApp
+    const componentName = this.el.getAttribute("data-name")
+    const component = componentName ? await resolve(componentName) : null
 
     const props = reactive(getProps(this.el, this.liveSocket))
     const slots = reactive(getSlots(this.el))
-    // let's apply initial stream diff here, since all stream changes are sent in that attribute
     applyPatch(props, getDiff(this.el, "data-streams-diff"))
 
     this.vue = { props, slots, app: null }
+    hooksById.set(this.el.id, this as LiveHook)
+
+    if (!component) return
+
+    const makeApp = this.el.getAttribute("data-ssr") === "true" ? createSSRApp : createApp
+
     const app = setup({
       createApp: makeApp,
       component,
@@ -124,6 +127,7 @@ export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
     Object.assign(this.vue.slots ?? {}, getSlots(this.el))
   },
   destroyed() {
+    hooksById.delete(this.el.id)
     const instance = this.vue.app
     // TODO - is there maybe a better way to cleanup the app?
     if (instance) {

--- a/assets/use.ts
+++ b/assets/use.ts
@@ -3,13 +3,24 @@ import type { MaybeRefOrGetter } from "vue"
 import type { LiveHook, UploadConfig, UploadEntry, UploadOptions } from "./types.js"
 
 export const liveInjectKey = "_live_vue"
+export const hooksById = new Map<string, LiveHook>()
 
 /**
- * Returns the LiveVue instance.
+ * Returns the LiveVue hook instance.
  * Can be used to access the LiveVue instance from within a LiveVue component.
  * It allows to e.g. push events to the LiveView.
+ *
+ * When called with an element ID, returns the hook attached to that element,
+ * giving access to another component's reactive props, slots, and LiveView connection.
+ *
+ * @param elementId - Optional ID of a LiveVue element to look up.
  */
-export const useLiveVue = (): LiveHook => {
+export function useLiveVue(): LiveHook
+export function useLiveVue(elementId: string): LiveHook | null
+export function useLiveVue(elementId?: string): LiveHook | null {
+  if (elementId) {
+    return hooksById.get(elementId) ?? null
+  }
   const live = inject<LiveHook>(liveInjectKey)
   if (!live) throw new Error("LiveVue not provided. Are you using this inside a LiveVue component?")
   return live

--- a/lib/live_vue.ex
+++ b/lib/live_vue.ex
@@ -112,6 +112,14 @@ defmodule LiveVue do
       assigns
       |> Map.put_new(:class, nil)
       |> Map.put(:__component_name, Map.get(assigns, :"v-component"))
+      |> then(fn assigns ->
+        if is_nil(assigns[:__component_name]) and is_nil(assigns[:id]) do
+          raise ArgumentError, "<.vue> without v-component requires an explicit id"
+        else
+          assigns
+        end
+      end)
+      |> then(fn assigns -> Map.put_new_lazy(assigns, :id, fn -> id(assigns.__component_name) end) end)
       |> Map.put(:props, props)
       # let's compress it a little bit, and decompress it on the client side
       |> Map.put(:props_diff, Enum.map(props_diff, &prepare_diff/1))
@@ -121,13 +129,13 @@ defmodule LiveVue do
       |> Map.put(:use_diff, use_diff)
 
     assigns =
-      Map.put(assigns, :ssr_render, if(render_ssr?, do: ssr_render(assigns)))
+      Map.put(assigns, :ssr_render, if(render_ssr? && assigns[:__component_name], do: ssr_render(assigns)))
 
     computed_changed =
       %{
         # we send initial props only on initial render, later we send only changed props
         props: init or dead or not use_diff,
-        ssr_render: render_ssr?,
+        ssr_render: assigns[:ssr_render] != nil,
         slots: slots != %{},
         handlers: handlers != %{},
         # we want to send props_diff always but not on initial render
@@ -145,9 +153,9 @@ defmodule LiveVue do
     # optimizing diffs by using string interpolation
     # https://elixirforum.com/t/heex-attribute-value-in-quotes-send-less-data-than-values-in-braces/63274
     ~H"""
-    {raw(@ssr_render[:preloadLinks])}
+    <%= if @ssr_render, do: raw(@ssr_render[:preloadLinks]) %>
     <div
-      id={assigns[:id] || id(@__component_name)}
+      id={@id}
       data-name={@__component_name}
       data-props={"#{json(Encoder.encode(@props))}"}
       data-props-diff={"#{json(@props_diff)}"}
@@ -160,7 +168,7 @@ defmodule LiveVue do
       phx-hook="VueHook"
       phx-no-format
       class={@class}
-    ><%= raw(@ssr_render[:html]) %></div>
+    ><%= if @ssr_render, do: raw(@ssr_render[:html]) %></div>
     """
   end
 

--- a/test/e2e/features/headless/display.vue
+++ b/test/e2e/features/headless/display.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useLiveVue } from "live_vue"
+
+const source = useLiveVue("data-source")
+</script>
+
+<template>
+  <div v-if="source">
+    <span data-pw-count>{{ source.vue.props.count }}</span>
+    <span data-pw-label>{{ source.vue.props.label }}</span>
+  </div>
+</template>

--- a/test/e2e/features/headless/headless.spec.js
+++ b/test/e2e/features/headless/headless.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test"
+import { syncLV } from "../../utils.js"
+
+test("headless component exposes reactive props via useLiveVue(elementId)", async ({ page }) => {
+  await page.goto("/headless")
+  await syncLV(page)
+
+  await expect(page.locator("[data-pw-count]")).toHaveText("0")
+  await expect(page.locator("[data-pw-label]")).toHaveText("Hello")
+
+  await page.locator("[data-pw-increment]").click()
+  await syncLV(page)
+  await expect(page.locator("[data-pw-count]")).toHaveText("1")
+
+  await page.locator("[data-pw-increment]").click()
+  await syncLV(page)
+  await expect(page.locator("[data-pw-count]")).toHaveText("2")
+})
+
+test("headless component updates non-numeric props reactively", async ({ page }) => {
+  await page.goto("/headless")
+  await syncLV(page)
+
+  await expect(page.locator("[data-pw-label]")).toHaveText("Hello")
+
+  await page.locator("[data-pw-label-input]").fill("Updated")
+  await page.locator("[data-pw-update-label]").click()
+  await syncLV(page)
+  await expect(page.locator("[data-pw-label]")).toHaveText("Updated")
+})
+
+test("headless component renders no visible UI", async ({ page }) => {
+  await page.goto("/headless")
+  await syncLV(page)
+
+  const headlessEl = page.locator("#data-source")
+  await expect(headlessEl).toBeAttached()
+  await expect(headlessEl).not.toHaveAttribute("data-name")
+  await expect(headlessEl).toHaveText("")
+})

--- a/test/e2e/features/headless/live.ex
+++ b/test/e2e/features/headless/live.ex
@@ -1,0 +1,28 @@
+defmodule LiveVue.E2E.HeadlessLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, count: 0, label: "Hello")}
+  end
+
+  def handle_event("increment", _params, socket) do
+    {:noreply, assign(socket, :count, socket.assigns.count + 1)}
+  end
+
+  def handle_event("update_label", %{"label" => label}, socket) do
+    {:noreply, assign(socket, :label, label)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <LiveVue.vue id="data-source" count={@count} label={@label} v-socket={@socket} />
+    <LiveVue.vue v-component="headless/display" v-socket={@socket} />
+    <button data-pw-increment phx-click="increment">Increment</button>
+    <form phx-submit="update_label">
+      <input type="text" name="label" data-pw-label-input />
+      <button type="submit" data-pw-update-label>Update</button>
+    </form>
+    """
+  end
+end

--- a/test/e2e/test_helper.exs
+++ b/test/e2e/test_helper.exs
@@ -131,6 +131,7 @@ defmodule LiveVue.E2E.Router do
       live "/slot-test", SlotTestLive
       live "/memory-benchmark", MemoryBenchmarkLive
       live "/reconnect", ReconnectLive
+      live "/headless", HeadlessLive
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds support for headless `<.vue>` elements (no `v-component`) that register in a global hook map keyed by element ID
- Extends `useLiveVue(elementId)` to look up another component's reactive props and LiveView connection by ID, enabling cross-component prop sharing without custom event plumbing
- Requires explicit `id` when `v-component` is omitted (raises at compile time otherwise)

## Test plan

- [ ] E2E test: headless component exposes reactive props via `useLiveVue(elementId)` — counter increments reactively
- [ ] E2E test: non-numeric props update reactively
- [ ] E2E test: headless element renders no visible UI and has no `data-name` attribute
- [ ] Run `npm run e2e:test` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)