### PR TITLE
chore: bump JS dependencies and add Vue peer dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 
 - Embedded the Vite SSR manifest into new server bundles at build time through `live_vue/ssrManifest`, avoiding runtime manifest file reads and keeping non-Node SSR bundles free of `fs` imports ([#126](https://github.com/Valian/live_vue/issues/126), [#137](https://github.com/Valian/live_vue/pull/137))
+- **Bumped installer dependencies to latest majors** ([#140](https://github.com/Valian/live_vue/pull/140)):
+  - Vite `^6.3.0` → `^8.0.0` (Rolldown-based bundler — significantly faster builds)
+  - `@vitejs/plugin-vue` `^5.0.4` → `^6.0.0`
+  - TypeScript `^5.4.5` → `^6.0.0`
+  - `vue-tsc` `^2.0.13` → `^3.0.0`
+  - `@vueuse/core` `^13.7.0` → `^14.0.0`
+  - TailwindCSS `^4.1.0` → `^4.2.0`, `@tailwindcss/vite` `^4.1.0` → `^4.2.0`
+- Declared `vue ^3.4.0` as a `peerDependency` of the library instead of injecting it into the user's `package.json` via the installer ([#140](https://github.com/Valian/live_vue/pull/140))
 
 ### Bug Fixes
 

--- a/lib/mix/tasks/live_vue.install.ex
+++ b/lib/mix/tasks/live_vue.install.ex
@@ -243,23 +243,22 @@ defmodule Mix.Tasks.LiveVue.Install do
           """
           {
             "dependencies": {
-              "@vueuse/core": "^13.7.0",
+              "@vueuse/core": "^14.0.0",
               "live_vue": "file:./deps/live_vue",
               "phoenix": "file:./deps/phoenix",
               "phoenix_html": "file:./deps/phoenix_html",
               "phoenix_live_view": "file:./deps/phoenix_live_view",
-              "topbar": "^3.0.0",
-              "vue": "^3.4.21"
+              "topbar": "^3.0.0"
             },
             "devDependencies": {
-              "@tailwindcss/vite": "^4.1.0",
-              "@vitejs/plugin-vue": "^5.0.4",
+              "@tailwindcss/vite": "^4.2.0",
+              "@vitejs/plugin-vue": "^6.0.0",
               "daisyui": "^5.0.0",
               "phoenix_vite": "file:./deps/phoenix_vite",
-              "tailwindcss": "^4.1.0",
-              "typescript": "^5.4.5",
-              "vite": "^6.3.0",
-              "vue-tsc": "^2.0.13"
+              "tailwindcss": "^4.2.0",
+              "typescript": "^6.0.0",
+              "vite": "^8.0.0",
+              "vue-tsc": "^3.0.0"
             }
           }
           """

--- a/package.json
+++ b/package.json
@@ -17,18 +17,21 @@
     "e2e:test:headed": "npm run e2e:build && npx playwright test --config test/e2e/playwright.config.js --headed",
     "e2e:test:debug": "npm run e2e:build && npx playwright test --config test/e2e/playwright.config.js --debug"
   },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  },
   "devDependencies": {
     "phoenix": "file:deps/phoenix",
     "phoenix_html": "file:deps/phoenix_html",
     "phoenix_live_view": "file:deps/phoenix_live_view",
     "@playwright/test": "^1.53.0",
     "@types/node": "^22.9.1",
-    "@vitejs/plugin-vue": "^5.2.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "@vitest/ui": "^3.2.4",
     "jsdom": "^26.1.0",
     "prettier": "2.8.7",
     "typescript": "^5.6.2",
-    "vite": "^5.4.8",
+    "vite": "^6.3.0",
     "vitest": "^3.2.4",
     "vue": "^3.5.10"
   },


### PR DESCRIPTION
## Summary

- Bump all installer dependencies to latest major versions (Vite 8, TypeScript 6, Vue-TSC 3, VueUse 14, plugin-vue 6, Tailwind 4.2)
- Move `vue` from installer-injected dependency to library `peerDependencies`, so version compatibility is formally declared and npm can detect conflicts automatically
- Bump library's own devDependencies (Vite 6, plugin-vue 6)

### Installer dependency changes

| Package | Before | After |
|---|---|---|
| `vite` | `^6.3.0` | `^8.0.0` |
| `@vitejs/plugin-vue` | `^5.0.4` | `^6.0.0` |
| `@vueuse/core` | `^13.7.0` | `^14.0.0` |
| `typescript` | `^5.4.5` | `^6.0.0` |
| `vue-tsc` | `^2.0.13` | `^3.0.0` |
| `tailwindcss` | `^4.1.0` | `^4.2.0` |
| `@tailwindcss/vite` | `^4.1.0` | `^4.2.0` |
| `vue` | `^3.4.21` (in deps) | removed (now a peer dep of live_vue) |

## Known issue: Vite 8 + DaisyUI build failure

Vite 8 switched from Rollup to Rolldown. There is a [known incompatibility](https://github.com/tailwindlabs/tailwindcss/pull/19949) between `@tailwindcss/vite` and DaisyUI's CSS imports when running on Vite 8 — the build fails with:

```
TypeError: Unknown file extension ".css" for .../node_modules/daisyui/daisyui.css
```

This is caused by Rolldown's ESM loader not handling `.css` file extensions during plugin resolution. The fix is merged in TailwindCSS and expected in `v4.2.5`.

### Temporary workaround

Until TailwindCSS 4.2.5 is released, replace the DaisyUI `@plugin` directives in `assets/css/app.css`:

```diff
-@plugin "daisyui" {
+@plugin "daisyui/index.js" {
   themes: false;
 }

-@plugin "daisyui/theme" {
+@plugin "daisyui/theme/index.js" {
   name: "dark";
   ...
 }
```

This explicitly points to the JS entry points, bypassing the `.css` resolution issue.

## Test plan

- [x] Smoke test passes with Vite 7 (no workaround needed)
- [x] Smoke test passes with Vite 8 + DaisyUI workaround
- [ ] Smoke test passes with Vite 8 after TailwindCSS 4.2.5 release (no workaround needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)