### PR TITLE
Compact LiveVue patch payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- %% CHANGELOG_ENTRIES %% -->
 
+## Unreleased
+
+### Improvements
+
+- Improved compact patch serialization performance and documented the compact patch wire format.
+
 ## 1.1.1 - 2026-05-04
 
 ### Bug Fixes

--- a/assets/attrs.ts
+++ b/assets/attrs.ts
@@ -1,6 +1,7 @@
 import { h } from "vue"
 import { mapValues, fromUtf8Base64 } from "./utils.js"
 import type { Operation } from "./jsonPatch.js"
+import { decodeCompactPatch } from "./compactPatch.js"
 
 export type SlotMap = Record<string, (slotProps?: Record<string, any>) => any>
 
@@ -23,12 +24,7 @@ export const getSlots = (el: HTMLElement): SlotMap => {
 }
 
 export const getDiff = (el: HTMLElement, attributeName: string): Operation[] => {
-  const dataPropsDiff = getAttributeJson(el, attributeName) || []
-  return dataPropsDiff.map(([op, path, value]: [string, string, any]) => ({
-    op,
-    path,
-    value,
-  }))
+  return decodeCompactPatch(el.getAttribute(attributeName))
 }
 
 /**
@@ -67,4 +63,3 @@ export const getProps = (el: HTMLElement, liveSocket: any): Record<string, any> 
 })
 
 export const getElementId = (el: HTMLElement): string | null => el.id || el.getAttribute("id")
-

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { decodeCompactPatch } from "./compactPatch"
+
+describe("decodeCompactPatch", () => {
+  it("decodes scalar add, replace, remove, and nonce operations", () => {
+    expect(decodeCompactPatch("n123r5:countn1:6a7:items.3s1:dd7:items.0")).toEqual([
+      { op: "replace", path: "/count", value: 6 },
+      { op: "add", path: "/items/3", value: "d" },
+      { op: "remove", path: "/items/0" },
+    ])
+  })
+
+  it("decodes base64url JSON values", () => {
+    expect(decodeCompactPatch("a4:rowsJ34:eyJpZCI6MywibmFtZSI6IkNoYXJsaWUifQ")).toEqual([
+      { op: "add", path: "/rows", value: { id: 3, name: "Charlie" } },
+    ])
+  })
+
+  it("decodes dot-separated paths back to JSON pointer paths", () => {
+    expect(decodeCompactPatch("r21:settings.a~1b~0c|d~2es5:value")).toEqual([
+      { op: "replace", path: "/settings/a~1b~0c|d.e", value: "value" },
+    ])
+  })
+
+  it("uses UTF-8 byte lengths for strings and paths", () => {
+    expect(decodeCompactPatch("r14:profile.na~2mes10:zażółć")).toEqual([
+      { op: "replace", path: "/profile/na.me", value: "zażółć" },
+    ])
+  })
+
+  it("decodes null, booleans, floats, upsert, and limit", () => {
+    expect(decodeCompactPatch("r5:titlezu5:itemsJ11:eyJpZCI6MX0l5:itemsn2:-3r4:flagb0r5:pricen4:22.5")).toEqual([
+      { op: "replace", path: "/title", value: null },
+      { op: "upsert", path: "/items", value: { id: 1 } },
+      { op: "limit", path: "/items", value: -3 },
+      { op: "replace", path: "/flag", value: false },
+      { op: "replace", path: "/price", value: 22.5 },
+    ])
+  })
+})

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -1,0 +1,124 @@
+import type { Operation } from "./jsonPatch.js"
+
+const opByCode: Record<string, Operation["op"]> = {
+  a: "add",
+  d: "remove",
+  r: "replace",
+  u: "upsert",
+  l: "limit",
+}
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+export const decodeCompactPatch = (payload: string | null): Operation[] => {
+  if (!payload) return []
+
+  const operations: Operation[] = []
+  let offset = 0
+
+  while (offset < payload.length) {
+    const code = payload[offset++]
+
+    if (code === "n") {
+      const result = readDigits(payload, offset)
+      offset = result.offset
+      continue
+    }
+
+    const op = opByCode[code]
+    if (!op) throw new Error(`Unknown LiveVue patch operation code: ${code}`)
+
+    const pathLength = readLength(payload, offset)
+    offset = pathLength.offset
+
+    const pathResult = readUtf8Bytes(payload, offset, pathLength.value)
+    offset = pathResult.offset
+    const path = decodePath(pathResult.value)
+
+    if (op === "remove") {
+      operations.push({ op, path })
+      continue
+    }
+
+    const valueResult = readValue(payload, offset)
+    offset = valueResult.offset
+    operations.push({ op, path, value: valueResult.value } as Operation)
+  }
+
+  return operations
+}
+
+const decodePath = (path: string): string => {
+  if (path === "") return ""
+  return `/${path
+    .split(".")
+    .map(segment => segment.replace(/~2/g, "."))
+    .join("/")}`
+}
+
+const readValue = (payload: string, offset: number): { value: any; offset: number } => {
+  const tag = payload[offset++]
+
+  switch (tag) {
+    case "z":
+      return { value: null, offset }
+    case "b":
+      return { value: payload[offset++] === "1", offset }
+    case "n": {
+      const result = readLengthPrefixed(payload, offset)
+      return { value: Number(result.value), offset: result.offset }
+    }
+    case "s":
+      return readLengthPrefixed(payload, offset)
+    case "J": {
+      const result = readLengthPrefixed(payload, offset)
+      return { value: JSON.parse(fromBase64Url(result.value)), offset: result.offset }
+    }
+    default:
+      throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
+  }
+}
+
+const readLengthPrefixed = (payload: string, offset: number): { value: string; offset: number } => {
+  const length = readLength(payload, offset)
+  const value = readUtf8Bytes(payload, length.offset, length.value)
+  return { value: value.value, offset: value.offset }
+}
+
+const readLength = (payload: string, offset: number): { value: number; offset: number } => {
+  const result = readDigits(payload, offset)
+  if (payload[result.offset] !== ":") throw new Error("Invalid LiveVue patch length prefix")
+  return { value: Number(result.value), offset: result.offset + 1 }
+}
+
+const readDigits = (payload: string, offset: number): { value: string; offset: number } => {
+  const start = offset
+  while (offset < payload.length && payload.charCodeAt(offset) >= 48 && payload.charCodeAt(offset) <= 57) offset++
+  return { value: payload.slice(start, offset), offset }
+}
+
+const readUtf8Bytes = (payload: string, offset: number, byteLength: number): { value: string; offset: number } => {
+  let end = offset
+  let bytes = 0
+
+  while (end < payload.length && bytes < byteLength) {
+    const codePoint = payload.codePointAt(end)
+    if (codePoint === undefined) break
+
+    const char = String.fromCodePoint(codePoint)
+    bytes += textEncoder.encode(char).length
+    end += char.length
+  }
+
+  if (bytes !== byteLength) throw new Error("Invalid LiveVue patch UTF-8 byte length")
+
+  return { value: payload.slice(offset, end), offset: end }
+}
+
+const fromBase64Url = (value: string): string => {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=")
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
+  return textDecoder.decode(bytes)
+}

--- a/assets/hooks.test.ts
+++ b/assets/hooks.test.ts
@@ -206,20 +206,19 @@ describe("getVueHook", () => {
       await vueHook.mounted!.call(mockHookContext)
 
       // Define a complex diff that modifies various parts of the props
-      const mockPropsDiff = [
-        ["replace", "/user/name", "Jane Smith"],
-        ["replace", "/user/age", 25],
-        ["add", "/user/email", "jane@example.com"],
-        ["replace", "/user/preferences/theme", "dark"],
-        ["add", "/items/-", "orange"], // Add to end of array
-        ["remove", "/items/0"], // Remove first item
-        ["replace", "/message", "Updated message"],
-        ["add", "/newTopLevelProp", "brand new property"]
-      ]
+      const mockPropsDiff =
+        "r9:user.names10:Jane Smith" +
+        "r8:user.agen2:25" +
+        "a10:user.emails16:jane@example.com" +
+        "r22:user.preferences.themes4:dark" +
+        "a7:items.-s6:orange" +
+        "d7:items.0" +
+        "r7:messages15:Updated message" +
+        "a15:newTopLevelProps18:brand new property"
 
       mockHookContext.el.getAttribute.mockImplementation((name: string) => {
         if (name === "data-use-diff") return "true"
-        if (name === "data-props-diff") return JSON.stringify(mockPropsDiff)
+        if (name === "data-props-diff") return mockPropsDiff
         return null
       })
 

--- a/lib/live_vue.ex
+++ b/lib/live_vue.ex
@@ -52,6 +52,7 @@ defmodule LiveVue do
 
   alias LiveVue.Encoder
   alias LiveVue.InjectedSSR
+  alias LiveVue.Patch
   alias LiveVue.Slots
   alias Phoenix.LiveView
   alias Phoenix.LiveView.LiveStream
@@ -126,8 +127,8 @@ defmodule LiveVue do
       |> then(fn assigns -> Map.put_new_lazy(assigns, :id, fn -> id(assigns.__component_name) end) end)
       |> Map.put(:props, props)
       # let's compress it a little bit, and decompress it on the client side
-      |> Map.put(:props_diff, Enum.map(props_diff, &prepare_diff/1))
-      |> Map.put(:streams_diff, Enum.map(streams_diff, &prepare_diff/1))
+      |> Map.put(:props_diff, serialize_patch(props_diff))
+      |> Map.put(:streams_diff, serialize_patch(streams_diff))
       |> Map.put(:handlers, handlers)
       |> Map.put(:slots, Slots.rendered_slot_map(slots))
       |> Map.put(:use_diff, use_diff)
@@ -166,8 +167,8 @@ defmodule LiveVue do
       id={@id}
       data-name={@__component_name}
       data-props={"#{json(Encoder.encode(@props))}"}
-      data-props-diff={"#{json(@props_diff)}"}
-      data-streams-diff={"#{json(@streams_diff)}"}
+      data-props-diff={"#{@props_diff}"}
+      data-streams-diff={"#{@streams_diff}"}
       data-ssr={(@ssr_render != nil) |> to_string()}
       data-use-diff={@use_diff |> to_string()}
       data-handlers={"#{for({k, v} <- @handlers, into: %{}, do: {k, json(v.ops)}) |> json()}"}
@@ -278,6 +279,12 @@ defmodule LiveVue do
 
   # we compress the diff to make it smaller, so it's faster to send to the client
   # then, it's decompressed on the client side
+  @doc false
+  def compress_patch(diff), do: Enum.map(diff, &prepare_diff/1)
+
+  @doc false
+  def serialize_patch(diff), do: Patch.serialize(diff)
+
   defp prepare_diff(%{op: op, path: p, value: value}), do: [op, p, value]
   defp prepare_diff(%{op: op, path: p}), do: [op, p]
 

--- a/lib/live_vue/patch.ex
+++ b/lib/live_vue/patch.ex
@@ -1,18 +1,8 @@
 defmodule LiveVue.Patch do
   @moduledoc false
 
-  @op_codes %{
-    "add" => "a",
-    "remove" => "d",
-    "replace" => "r",
-    "upsert" => "u",
-    "limit" => "l"
-  }
-
-  @ops_by_code Map.new(@op_codes, fn {op, code} -> {code, op} end)
-
   def serialize(patches) do
-    Enum.map_join(patches, "", &serialize_op/1)
+    :erlang.iolist_to_binary(for patch <- patches, do: serialize_op(patch))
   end
 
   def deserialize(""), do: []
@@ -23,35 +13,39 @@ defmodule LiveVue.Patch do
     |> Enum.reverse()
   end
 
-  defp serialize_op(%{op: "test", path: "", value: nonce}), do: "n#{nonce}"
+  defp serialize_op(%{op: "test", path: "", value: nonce}), do: ["n", to_string(nonce)]
 
   defp serialize_op(%{op: op, path: path, value: value}) do
     path = encode_path(path)
-    "#{op_code(op)}#{byte_size(path)}:#{path}#{encode_value(value)}"
+    [op_code(op), Integer.to_string(byte_size(path)), ?:, path, encode_value(value)]
   end
 
   defp serialize_op(%{op: op, path: path}) do
     path = encode_path(path)
-    "#{op_code(op)}#{byte_size(path)}:#{path}"
+    [op_code(op), Integer.to_string(byte_size(path)), ?:, path]
   end
 
   defp encode_path(""), do: ""
 
   defp encode_path("/" <> rest) do
-    rest
-    |> String.split("/")
-    |> Enum.map_join(".", &String.replace(&1, ".", "~2"))
+    encode_path(rest, [])
   end
 
+  defp encode_path(<<>>, acc), do: acc |> :lists.reverse() |> :erlang.iolist_to_binary()
+  defp encode_path(<<?/, rest::binary>>, acc), do: encode_path(rest, [?. | acc])
+  defp encode_path(<<?., rest::binary>>, acc), do: encode_path(rest, ["~2" | acc])
+  defp encode_path(<<char, rest::binary>>, acc), do: encode_path(rest, [char | acc])
+
   defp encode_value(nil), do: "z"
-  defp encode_value(value) when is_boolean(value), do: "b#{if(value, do: 1, else: 0)}"
+  defp encode_value(true), do: "b1"
+  defp encode_value(false), do: "b0"
 
   defp encode_value(value) when is_number(value) do
     encoded = to_string(value)
-    "n#{byte_size(encoded)}:#{encoded}"
+    ["n", Integer.to_string(byte_size(encoded)), ?:, encoded]
   end
 
-  defp encode_value(value) when is_binary(value), do: "s#{byte_size(value)}:#{value}"
+  defp encode_value(value) when is_binary(value), do: ["s", Integer.to_string(byte_size(value)), ?:, value]
 
   defp encode_value(value) do
     encoded =
@@ -59,7 +53,7 @@ defmodule LiveVue.Patch do
       |> Jason.encode!()
       |> Base.url_encode64(padding: false)
 
-    "J#{byte_size(encoded)}:#{encoded}"
+    ["J", Integer.to_string(byte_size(encoded)), ?:, encoded]
   end
 
   defp parse_ops("", acc), do: acc
@@ -75,12 +69,14 @@ defmodule LiveVue.Patch do
     op = op_from_code(code)
     path = decode_path(path)
 
-    if op in ["remove"] do
-      parse_ops(rest, [[op, path] | acc])
-    else
-      {value, rest} = parse_value(rest)
-      parse_ops(rest, [[op, path, value] | acc])
-    end
+    parse_op(op, path, rest, acc)
+  end
+
+  defp parse_op("remove", path, rest, acc), do: parse_ops(rest, [["remove", path] | acc])
+
+  defp parse_op(op, path, rest, acc) do
+    {value, rest} = parse_value(rest)
+    parse_ops(rest, [[op, path, value] | acc])
   end
 
   defp parse_value("z" <> rest), do: {nil, rest}
@@ -104,11 +100,13 @@ defmodule LiveVue.Patch do
   defp decode_path(""), do: ""
 
   defp decode_path(path) do
-    "/" <>
-      (path
-       |> String.split(".")
-       |> Enum.map_join("/", &String.replace(&1, "~2", ".")))
+    :erlang.iolist_to_binary([?/ | decode_path(path, [])])
   end
+
+  defp decode_path(<<>>, acc), do: :lists.reverse(acc)
+  defp decode_path(<<?., rest::binary>>, acc), do: decode_path(rest, [?/ | acc])
+  defp decode_path(<<?~, ?2, rest::binary>>, acc), do: decode_path(rest, [?. | acc])
+  defp decode_path(<<char, rest::binary>>, acc), do: decode_path(rest, [char | acc])
 
   defp parse_number(value) do
     case Integer.parse(value) do
@@ -134,6 +132,15 @@ defmodule LiveVue.Patch do
 
   defp take_digits(rest, acc), do: {acc, rest}
 
-  defp op_code(op), do: Map.fetch!(@op_codes, op)
-  defp op_from_code(code), do: Map.fetch!(@ops_by_code, code)
+  defp op_code("add"), do: "a"
+  defp op_code("remove"), do: "d"
+  defp op_code("replace"), do: "r"
+  defp op_code("upsert"), do: "u"
+  defp op_code("limit"), do: "l"
+
+  defp op_from_code("a"), do: "add"
+  defp op_from_code("d"), do: "remove"
+  defp op_from_code("r"), do: "replace"
+  defp op_from_code("u"), do: "upsert"
+  defp op_from_code("l"), do: "limit"
 end

--- a/lib/live_vue/patch.ex
+++ b/lib/live_vue/patch.ex
@@ -1,10 +1,66 @@
 defmodule LiveVue.Patch do
-  @moduledoc false
+  @moduledoc """
+  Encodes LiveVue patch operations into the compact wire format used by
+  `data-props-diff` and `data-streams-diff`.
 
+  The payload is a concatenated sequence of operations. Dynamic text fields are
+  byte-length-prefixed, so paths and values can contain delimiters without extra
+  escaping.
+
+  Operation codes:
+
+  | Code | Operation |
+  | --- | --- |
+  | `a` | `add` |
+  | `d` | `remove` |
+  | `r` | `replace` |
+  | `u` | `upsert` |
+  | `l` | `limit` |
+  | `n` | nonce marker, ignored while decoding |
+
+  Normal operations use:
+
+  ```text
+  <op><path_byte_len>:<path><value>
+  ```
+
+  `remove` omits `<value>`. The nonce marker uses `n<digits>` and exists only
+  to force LiveView to send a changed attribute.
+
+  Value tags:
+
+  | Tag | Value |
+  | --- | --- |
+  | `z` | `nil` |
+  | `b0`, `b1` | booleans |
+  | `n<len>:<number>` | number |
+  | `s<len>:<utf8 string>` | string |
+  | `J<len>:<base64url JSON>` | maps, lists, and complex values |
+
+  Paths are encoded from JSON Pointer form by removing the leading slash,
+  joining segments with `.`, and escaping literal `.` as `~2`. Existing JSON
+  Pointer escapes such as `~0` and `~1` are preserved.
+  """
+
+  @doc """
+  Serializes patch maps into a compact binary payload.
+
+  Expected patch shapes are `%{op: op, path: path, value: value}`,
+  `%{op: "remove", path: path}`, and `%{op: "test", path: "", value: nonce}`.
+  The nonce test operation is encoded as a marker and is not returned by
+  `deserialize/1`.
+  """
   def serialize(patches) do
     :erlang.iolist_to_binary(for patch <- patches, do: serialize_op(patch))
   end
 
+  @doc """
+  Deserializes a compact patch payload into list-shaped operations.
+
+  Returns `[]` for an empty payload. Decoded operations are shaped as
+  `[op, path]` for `remove` and `[op, path, value]` for all value-bearing
+  operations. Nonce markers are skipped.
+  """
   def deserialize(""), do: []
 
   def deserialize(payload) when is_binary(payload) do

--- a/lib/live_vue/patch.ex
+++ b/lib/live_vue/patch.ex
@@ -1,0 +1,139 @@
+defmodule LiveVue.Patch do
+  @moduledoc false
+
+  @op_codes %{
+    "add" => "a",
+    "remove" => "d",
+    "replace" => "r",
+    "upsert" => "u",
+    "limit" => "l"
+  }
+
+  @ops_by_code Map.new(@op_codes, fn {op, code} -> {code, op} end)
+
+  def serialize(patches) do
+    Enum.map_join(patches, "", &serialize_op/1)
+  end
+
+  def deserialize(""), do: []
+
+  def deserialize(payload) when is_binary(payload) do
+    payload
+    |> parse_ops([])
+    |> Enum.reverse()
+  end
+
+  defp serialize_op(%{op: "test", path: "", value: nonce}), do: "n#{nonce}"
+
+  defp serialize_op(%{op: op, path: path, value: value}) do
+    path = encode_path(path)
+    "#{op_code(op)}#{byte_size(path)}:#{path}#{encode_value(value)}"
+  end
+
+  defp serialize_op(%{op: op, path: path}) do
+    path = encode_path(path)
+    "#{op_code(op)}#{byte_size(path)}:#{path}"
+  end
+
+  defp encode_path(""), do: ""
+
+  defp encode_path("/" <> rest) do
+    rest
+    |> String.split("/")
+    |> Enum.map_join(".", &String.replace(&1, ".", "~2"))
+  end
+
+  defp encode_value(nil), do: "z"
+  defp encode_value(value) when is_boolean(value), do: "b#{if(value, do: 1, else: 0)}"
+
+  defp encode_value(value) when is_number(value) do
+    encoded = to_string(value)
+    "n#{byte_size(encoded)}:#{encoded}"
+  end
+
+  defp encode_value(value) when is_binary(value), do: "s#{byte_size(value)}:#{value}"
+
+  defp encode_value(value) do
+    encoded =
+      value
+      |> Jason.encode!()
+      |> Base.url_encode64(padding: false)
+
+    "J#{byte_size(encoded)}:#{encoded}"
+  end
+
+  defp parse_ops("", acc), do: acc
+
+  defp parse_ops("n" <> rest, acc) do
+    {_nonce, rest} = take_digits(rest)
+    parse_ops(rest, acc)
+  end
+
+  defp parse_ops(<<code::binary-size(1), rest::binary>>, acc) do
+    {path_length, rest} = take_length(rest)
+    <<path::binary-size(path_length), rest::binary>> = rest
+    op = op_from_code(code)
+    path = decode_path(path)
+
+    if op in ["remove"] do
+      parse_ops(rest, [[op, path] | acc])
+    else
+      {value, rest} = parse_value(rest)
+      parse_ops(rest, [[op, path, value] | acc])
+    end
+  end
+
+  defp parse_value("z" <> rest), do: {nil, rest}
+  defp parse_value("b1" <> rest), do: {true, rest}
+  defp parse_value("b0" <> rest), do: {false, rest}
+
+  defp parse_value(<<tag::binary-size(1), rest::binary>>) when tag in ["n", "s", "J"] do
+    {length, rest} = take_length(rest)
+    <<encoded::binary-size(length), rest::binary>> = rest
+
+    value =
+      case tag do
+        "n" -> parse_number(encoded)
+        "s" -> encoded
+        "J" -> encoded |> Base.url_decode64!(padding: false) |> Jason.decode!()
+      end
+
+    {value, rest}
+  end
+
+  defp decode_path(""), do: ""
+
+  defp decode_path(path) do
+    "/" <>
+      (path
+       |> String.split(".")
+       |> Enum.map_join("/", &String.replace(&1, "~2", ".")))
+  end
+
+  defp parse_number(value) do
+    case Integer.parse(value) do
+      {integer, ""} ->
+        integer
+
+      _ ->
+        {float, ""} = Float.parse(value)
+        float
+    end
+  end
+
+  defp take_length(payload) do
+    {digits, ":" <> rest} = take_digits(payload)
+    {String.to_integer(digits), rest}
+  end
+
+  defp take_digits(payload), do: take_digits(payload, "")
+
+  defp take_digits(<<char, rest::binary>>, acc) when char in ?0..?9 do
+    take_digits(rest, <<acc::binary, char>>)
+  end
+
+  defp take_digits(rest, acc), do: {acc, rest}
+
+  defp op_code(op), do: Map.fetch!(@op_codes, op)
+  defp op_from_code(code), do: Map.fetch!(@ops_by_code, code)
+end

--- a/lib/live_vue/test.ex
+++ b/lib/live_vue/test.ex
@@ -102,12 +102,13 @@ defmodule LiveVue.Test do
 
   def get_vue(html, opts) when is_binary(html) do
     if Code.ensure_loaded?(LazyHTML) do
-      lazy_html =
+      components =
         html
         |> LazyHTML.from_document()
-        |> LazyHTML.query("[phx-hook='VueHook']")
+        |> LazyHTML.to_tree()
+        |> vue_components()
 
-      vue_tree = find_component!(lazy_html, opts)
+      vue_tree = find_component!(components, opts)
 
       %{
         props: Jason.decode!(attr_from_tree(vue_tree, "data-props")),
@@ -118,8 +119,8 @@ defmodule LiveVue.Test do
         ssr: vue_tree |> attr_from_tree("data-ssr") |> String.to_existing_atom(),
         use_diff: vue_tree |> attr_from_tree("data-use-diff") |> String.to_existing_atom(),
         class: attr_from_tree(vue_tree, "class"),
-        props_diff: Jason.decode!(attr_from_tree(vue_tree, "data-props-diff")),
-        streams_diff: Jason.decode!(attr_from_tree(vue_tree, "data-streams-diff")),
+        props_diff: LiveVue.Patch.deserialize(attr_from_tree(vue_tree, "data-props-diff")),
+        streams_diff: LiveVue.Patch.deserialize(attr_from_tree(vue_tree, "data-streams-diff")),
         doc: vue_tree
       }
     else
@@ -150,12 +151,10 @@ defmodule LiveVue.Test do
   end
 
   defp find_component!(components, opts) do
-    components_tree = LazyHTML.to_tree(components)
-
-    available = Enum.map_join(components_tree, ", ", &"#{attr_from_tree(&1, "data-name")}##{attr_from_tree(&1, "id")}")
+    available = Enum.map_join(components, ", ", &"#{attr_from_tree(&1, "data-name")}##{attr_from_tree(&1, "id")}")
 
     matched =
-      Enum.reduce(opts, components_tree, fn
+      Enum.reduce(opts, components, fn
         {:id, id}, result ->
           with [] <- Enum.filter(result, &(attr_from_tree(&1, "id") == id)) do
             raise "No Vue component found with id=\"#{id}\". Available components: #{available}"
@@ -185,4 +184,18 @@ defmodule LiveVue.Test do
       nil -> nil
     end
   end
+
+  defp vue_components(tree) when is_list(tree), do: Enum.flat_map(tree, &vue_components/1)
+
+  defp vue_components({_tag, attrs, children} = node) do
+    rest = vue_components(children)
+
+    if Enum.any?(attrs, fn {key, value} -> key == "phx-hook" and value == "VueHook" end) do
+      [node | rest]
+    else
+      rest
+    end
+  end
+
+  defp vue_components(_), do: []
 end

--- a/test/live_vue_patch_test.exs
+++ b/test/live_vue_patch_test.exs
@@ -3,41 +3,186 @@ defmodule LiveVuePatchTest do
 
   alias LiveVue.Patch
 
-  test "serializes and deserializes scalar operations" do
-    patches = [
-      %{op: "test", path: "", value: 123},
-      %{op: "replace", path: "/count", value: 6},
-      %{op: "add", path: "/items/3", value: "d"},
-      %{op: "remove", path: "/items/0"}
-    ]
+  describe "values" do
+    test "round-trips nil" do
+      patches = [%{op: "replace", path: "/value", value: nil}]
 
-    assert Patch.serialize(patches) == "n123r5:countn1:6a7:items.3s1:dd7:items.0"
+      assert serialize_deserialize(patches) == patches
+    end
 
-    assert Patch.deserialize(Patch.serialize(patches)) == [
-             ["replace", "/count", 6],
-             ["add", "/items/3", "d"],
-             ["remove", "/items/0"]
-           ]
+    test "round-trips booleans" do
+      patches = [
+        %{op: "replace", path: "/enabled", value: true},
+        %{op: "replace", path: "/disabled", value: false}
+      ]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips integers" do
+      patches = [%{op: "replace", path: "/count", value: 6}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips floats" do
+      patches = [%{op: "replace", path: "/price", value: 12.5}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips strings" do
+      patches = [%{op: "replace", path: "/title", value: "Published"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips lists" do
+      patches = [%{op: "replace", path: "/tags", value: ["bug", "urgent"]}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips maps" do
+      patches = [%{op: "replace", path: "/user", value: %{"id" => 3, "name" => "Charlie"}}]
+
+      assert serialize_deserialize(patches) == patches
+    end
   end
 
-  test "uses base64url JSON for complex values" do
-    patches = [%{op: "add", path: "/rows", value: %{id: 3, name: "Charlie"}}]
+  describe "paths" do
+    test "round-trips the document root path" do
+      patches = [%{op: "replace", path: "", value: %{"status" => "ready"}}]
 
-    assert Patch.serialize(patches) == "a4:rowsJ34:eyJpZCI6MywibmFtZSI6IkNoYXJsaWUifQ"
-    assert Patch.deserialize(Patch.serialize(patches)) == [["add", "/rows", %{"id" => 3, "name" => "Charlie"}]]
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips nested paths" do
+      patches = [%{op: "replace", path: "/profile/name", value: "Ada"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips array index paths" do
+      patches = [%{op: "replace", path: "/items/0/name", value: "Keyboard"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips append marker paths" do
+      patches = [%{op: "add", path: "/items/-", value: "new"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips dots inside path segments" do
+      patches = [%{op: "replace", path: "/settings/a.b.c", value: "value"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips JSON pointer escapes in path segments" do
+      patches = [%{op: "replace", path: "/settings/a~1b~0c", value: "value"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips UTF-8 paths and values using byte lengths" do
+      patches = [%{op: "replace", path: "/profile/na.me", value: "zażółć"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
   end
 
-  test "escapes dots in path segments while preserving JSON pointer escapes" do
-    patches = [%{op: "replace", path: "/settings/a~1b~0c|d.e", value: "value"}]
+  describe "operations" do
+    test "round-trips an empty patch list" do
+      patches = []
 
-    assert Patch.serialize(patches) == "r21:settings.a~1b~0c|d~2es5:value"
-    assert Patch.deserialize(Patch.serialize(patches)) == [["replace", "/settings/a~1b~0c|d.e", "value"]]
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips remove operations without a value" do
+      patches = [%{op: "remove", path: "/items/0"}]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "omits nonce test operations when deserializing" do
+      patches = [
+        %{op: "test", path: "", value: 123},
+        %{op: "replace", path: "/count", value: 6}
+      ]
+
+      assert serialize_deserialize(patches) == [%{op: "replace", path: "/count", value: 6}]
+    end
   end
 
-  test "uses UTF-8 byte lengths" do
-    patches = [%{op: "replace", path: "/profile/na.me", value: "zażółć"}]
+  describe "complex patches" do
+    test "round-trips mixed scalar operations" do
+      patches = [
+        %{op: "replace", path: "/count", value: 6},
+        %{op: "add", path: "/items/3", value: "d"},
+        %{op: "remove", path: "/items/0"}
+      ]
 
-    assert Patch.serialize(patches) == "r14:profile.na~2mes10:zażółć"
-    assert Patch.deserialize(Patch.serialize(patches)) == [["replace", "/profile/na.me", "zażółć"]]
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips nested object updates" do
+      patches = [
+        %{
+          op: "replace",
+          path: "/form/errors",
+          value: %{
+            "email" => ["must have the @ sign"],
+            "age" => ["must be greater than 18"]
+          }
+        },
+        %{op: "replace", path: "/form/touched", value: %{"email" => true, "age" => true}}
+      ]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips stream upsert and limit operations" do
+      patches = [
+        %{
+          op: "upsert",
+          path: "/users/-",
+          value: %{"id" => 4, "name" => "Margaret Hamilton", "role" => "guest"}
+        },
+        %{op: "limit", path: "/users", value: 10}
+      ]
+
+      assert serialize_deserialize(patches) == patches
+    end
+
+    test "round-trips multiple nested lists and objects" do
+      patches = [
+        %{
+          op: "replace",
+          path: "/cart/items/1",
+          value: %{"id" => "sku-2", "name" => "Mouse", "qty" => 3, "price" => 49.5}
+        },
+        %{
+          op: "replace",
+          path: "/cart/totals",
+          value: %{"subtotal" => 277.5, "tax" => 22.2, "total" => 299.7}
+        },
+        %{op: "replace", path: "/cart/coupon", value: nil}
+      ]
+
+      assert serialize_deserialize(patches) == patches
+    end
   end
+
+  defp serialize_deserialize(patches) do
+    patches
+    |> Patch.serialize()
+    |> Patch.deserialize()
+    |> Enum.map(&patch_from_wire/1)
+  end
+
+  defp patch_from_wire([op, path]), do: %{op: op, path: path}
+  defp patch_from_wire([op, path, value]), do: %{op: op, path: path, value: value}
 end

--- a/test/live_vue_patch_test.exs
+++ b/test/live_vue_patch_test.exs
@@ -1,0 +1,43 @@
+defmodule LiveVuePatchTest do
+  use ExUnit.Case
+
+  alias LiveVue.Patch
+
+  test "serializes and deserializes scalar operations" do
+    patches = [
+      %{op: "test", path: "", value: 123},
+      %{op: "replace", path: "/count", value: 6},
+      %{op: "add", path: "/items/3", value: "d"},
+      %{op: "remove", path: "/items/0"}
+    ]
+
+    assert Patch.serialize(patches) == "n123r5:countn1:6a7:items.3s1:dd7:items.0"
+
+    assert Patch.deserialize(Patch.serialize(patches)) == [
+             ["replace", "/count", 6],
+             ["add", "/items/3", "d"],
+             ["remove", "/items/0"]
+           ]
+  end
+
+  test "uses base64url JSON for complex values" do
+    patches = [%{op: "add", path: "/rows", value: %{id: 3, name: "Charlie"}}]
+
+    assert Patch.serialize(patches) == "a4:rowsJ34:eyJpZCI6MywibmFtZSI6IkNoYXJsaWUifQ"
+    assert Patch.deserialize(Patch.serialize(patches)) == [["add", "/rows", %{"id" => 3, "name" => "Charlie"}]]
+  end
+
+  test "escapes dots in path segments while preserving JSON pointer escapes" do
+    patches = [%{op: "replace", path: "/settings/a~1b~0c|d.e", value: "value"}]
+
+    assert Patch.serialize(patches) == "r21:settings.a~1b~0c|d~2es5:value"
+    assert Patch.deserialize(Patch.serialize(patches)) == [["replace", "/settings/a~1b~0c|d.e", "value"]]
+  end
+
+  test "uses UTF-8 byte lengths" do
+    patches = [%{op: "replace", path: "/profile/na.me", value: "zażółć"}]
+
+    assert Patch.serialize(patches) == "r14:profile.na~2mes10:zażółć"
+    assert Patch.deserialize(Patch.serialize(patches)) == [["replace", "/profile/na.me", "zażółć"]]
+  end
+end


### PR DESCRIPTION
## Summary

This changes `data-props-diff` and `data-streams-diff` from JSON-encoded patch arrays to a compact string wire format shared by the Elixir serializer and TypeScript decoder.

The new format is intentionally attribute-safe and avoids the biggest double-encoding costs from JSON strings inside HTML attributes inside LiveView JSON frames.

## Wire Format

A payload is a concatenated sequence of operations:

```text
<op><path_byte_len>:<path><value>
```

Operation codes:

```text
a = add
d = remove
r = replace
u = upsert
l = limit
n = nonce marker, used only to force LiveView to send a changed attribute
```

Value tags:

```text
z                 null
b0 / b1           booleans
n<len>:<number>   numbers
s<len>:<string>   UTF-8 strings
J<len>:<payload>  base64url-encoded JSON for maps/lists/complex values
```

Paths are encoded from JSON Pointer to dot-separated segments to avoid LiveView's extra `/` escaping:

```text
/data/simple_string       -> data.simple_string
/settings/a~1b~0c|d.e     -> settings.a~1b~0c|d~2e
```

Existing JSON Pointer escapes are preserved, and literal `.` inside a path segment is encoded as `~2`. Paths and values are byte-length-prefixed, so delimiters inside data do not need escaping.

Example payloads:

```text
n3878027r5:countn1:6
n3298474r18:data.simple_strings7:changed
n662909a19:data.list_of_maps.2J54:eyJpZCI6MywibmFtZSI6IkNoYXJsaWUiLCJyb2xlIjoiZ3Vlc3QifQ
```

## Expected Savings

Using the 24-scenario wire benchmark developed for this change:

```text
old JSON-array format: 4521 variable wire payload bytes
new compact format:   1937 variable wire payload bytes
```

That is about a 57% reduction in the actual variable `data-props-diff` payload. The synthetic full LiveView reply estimate drops from 6825 bytes to 4241 bytes across the same scenarios.

The fixed LiveView wrapper cost is not counted in the main percentage above; the savings figure compares only the escaped attribute value that changes per patch.

## Validation

```text
MIX_ENV=test mix test      -> 211 passed
npm test -- --run          -> 257 passed
npm run e2e:test           -> 94 passed
```

## Notes

Only the runtime implementation and tests are included in this PR. The local benchmark/research scripts used to compare alternative encodings were intentionally left out of the commit.
