### PR TITLE
Compact full props and JSON patch values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 
 - Improved compact patch serialization performance and documented the compact patch wire format.
+- Reduced LiveVue wire payload size by caret-encoding full props and complex patch values instead of relying on HTML-safe JSON/base64url JSON.
 
 ## 1.1.1 - 2026-05-04
 

--- a/assets/attrs.ts
+++ b/assets/attrs.ts
@@ -1,7 +1,7 @@
 import { h } from "vue"
 import { mapValues, fromUtf8Base64 } from "./utils.js"
 import type { Operation } from "./jsonPatch.js"
-import { decodeCompactPatch } from "./compactPatch.js"
+import { decodeCompactJson, decodeCompactPatch } from "./compactPatch.js"
 
 export type SlotMap = Record<string, (slotProps?: Record<string, any>) => any>
 
@@ -58,7 +58,7 @@ export const getHandlers = (el: HTMLElement, liveSocket: any): Record<string, (e
  * The props are merged with the event handlers from the "data-handlers" attribute.
  */
 export const getProps = (el: HTMLElement, liveSocket: any): Record<string, any> => ({
-  ...(getAttributeJson(el, "data-props") || {}),
+  ...decodeCompactJson(el.getAttribute("data-props") || "{}"),
   ...getHandlers(el, liveSocket),
 })
 

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -3,33 +3,33 @@ import { decodeCompactPatch } from "./compactPatch"
 
 describe("decodeCompactPatch", () => {
   it("decodes scalar add, replace, remove, and nonce operations", () => {
-    expect(decodeCompactPatch("n123r5:countn1:6a7:items.3s1:dd7:items.0")).toEqual([
+    expect(decodeCompactPatch("n123r6:/countn1:6a8:/items/3s1:dd8:/items/0")).toEqual([
       { op: "replace", path: "/count", value: 6 },
       { op: "add", path: "/items/3", value: "d" },
       { op: "remove", path: "/items/0" },
     ])
   })
 
-  it("decodes base64url JSON values", () => {
-    expect(decodeCompactPatch("a4:rowsJ34:eyJpZCI6MywibmFtZSI6IkNoYXJsaWUifQ")).toEqual([
+  it("decodes caret-encoded JSON values", () => {
+    expect(decodeCompactPatch("a5:/rowsJ25:{^id^:3,^name^:^Charlie^}")).toEqual([
       { op: "add", path: "/rows", value: { id: 3, name: "Charlie" } },
     ])
   })
 
-  it("decodes dot-separated paths back to JSON pointer paths", () => {
-    expect(decodeCompactPatch("r21:settings.a~1b~0c|d~2es5:value")).toEqual([
+  it("decodes JSON pointer paths", () => {
+    expect(decodeCompactPatch("r21:/settings/a~1b~0c|d.es5:value")).toEqual([
       { op: "replace", path: "/settings/a~1b~0c|d.e", value: "value" },
     ])
   })
 
   it("uses UTF-8 byte lengths for strings and paths", () => {
-    expect(decodeCompactPatch("r14:profile.na~2mes10:zażółć")).toEqual([
+    expect(decodeCompactPatch("r14:/profile/na.mes10:zażółć")).toEqual([
       { op: "replace", path: "/profile/na.me", value: "zażółć" },
     ])
   })
 
   it("decodes null, booleans, floats, upsert, and limit", () => {
-    expect(decodeCompactPatch("r5:titlezu5:itemsJ11:eyJpZCI6MX0l5:itemsn2:-3r4:flagb0r5:pricen4:22.5")).toEqual([
+    expect(decodeCompactPatch("r6:/titlezu6:/itemsJ8:{^id^:1}l6:/itemsn2:-3r5:/flagb0r6:/pricen4:22.5")).toEqual([
       { op: "replace", path: "/title", value: null },
       { op: "upsert", path: "/items", value: { id: 1 } },
       { op: "limit", path: "/items", value: -3 },

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -9,7 +9,6 @@ const opByCode: Record<string, Operation["op"]> = {
 }
 
 const textEncoder = new TextEncoder()
-const textDecoder = new TextDecoder()
 
 export const decodeCompactPatch = (payload: string | null): Operation[] => {
   if (!payload) return []
@@ -34,7 +33,7 @@ export const decodeCompactPatch = (payload: string | null): Operation[] => {
 
     const pathResult = readUtf8Bytes(payload, offset, pathLength.value)
     offset = pathResult.offset
-    const path = decodePath(pathResult.value)
+    const path = pathResult.value
 
     if (op === "remove") {
       operations.push({ op, path })
@@ -47,14 +46,6 @@ export const decodeCompactPatch = (payload: string | null): Operation[] => {
   }
 
   return operations
-}
-
-const decodePath = (path: string): string => {
-  if (path === "") return ""
-  return `/${path
-    .split(".")
-    .map(segment => segment.replace(/~2/g, "."))
-    .join("/")}`
 }
 
 const readValue = (payload: string, offset: number): { value: any; offset: number } => {
@@ -73,7 +64,7 @@ const readValue = (payload: string, offset: number): { value: any; offset: numbe
       return readLengthPrefixed(payload, offset)
     case "J": {
       const result = readLengthPrefixed(payload, offset)
-      return { value: JSON.parse(fromBase64Url(result.value)), offset: result.offset }
+      return { value: decodeCompactJson(result.value), offset: result.offset }
     }
     default:
       throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
@@ -116,9 +107,10 @@ const readUtf8Bytes = (payload: string, offset: number, byteLength: number): { v
   return { value: payload.slice(offset, end), offset: end }
 }
 
-const fromBase64Url = (value: string): string => {
-  const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=")
-  const binary = atob(padded)
-  const bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
-  return textDecoder.decode(bytes)
+export const decodeCompactJson = (value: string): any => {
+  return JSON.parse(value.replace(/~~|~\^|\^/g, match => {
+    if (match === "~~") return "~"
+    if (match === "~^") return "^"
+    return "\""
+  }))
 }

--- a/assets/hooks.test.ts
+++ b/assets/hooks.test.ts
@@ -207,14 +207,14 @@ describe("getVueHook", () => {
 
       // Define a complex diff that modifies various parts of the props
       const mockPropsDiff =
-        "r9:user.names10:Jane Smith" +
-        "r8:user.agen2:25" +
-        "a10:user.emails16:jane@example.com" +
-        "r22:user.preferences.themes4:dark" +
-        "a7:items.-s6:orange" +
-        "d7:items.0" +
-        "r7:messages15:Updated message" +
-        "a15:newTopLevelProps18:brand new property"
+        "r10:/user/names10:Jane Smith" +
+        "r9:/user/agen2:25" +
+        "a11:/user/emails16:jane@example.com" +
+        "r23:/user/preferences/themes4:dark" +
+        "a8:/items/-s6:orange" +
+        "d8:/items/0" +
+        "r8:/messages15:Updated message" +
+        "a16:/newTopLevelProps18:brand new property"
 
       mockHookContext.el.getAttribute.mockImplementation((name: string) => {
         if (name === "data-use-diff") return "true"

--- a/lib/live_vue.ex
+++ b/lib/live_vue.ex
@@ -166,7 +166,7 @@ defmodule LiveVue do
     <div
       id={@id}
       data-name={@__component_name}
-      data-props={"#{json(Encoder.encode(@props))}"}
+      data-props={"#{Patch.encode_object(Encoder.encode(@props))}"}
       data-props-diff={"#{@props_diff}"}
       data-streams-diff={"#{@streams_diff}"}
       data-ssr={(@ssr_render != nil) |> to_string()}

--- a/lib/live_vue/patch.ex
+++ b/lib/live_vue/patch.ex
@@ -35,11 +35,9 @@ defmodule LiveVue.Patch do
   | `b0`, `b1` | booleans |
   | `n<len>:<number>` | number |
   | `s<len>:<utf8 string>` | string |
-  | `J<len>:<base64url JSON>` | maps, lists, and complex values |
+  | `J<len>:<caret-encoded JSON>` | maps, lists, and complex values |
 
-  Paths are encoded from JSON Pointer form by removing the leading slash,
-  joining segments with `.`, and escaping literal `.` as `~2`. Existing JSON
-  Pointer escapes such as `~0` and `~1` are preserved.
+  Paths are transported as JSON Pointer strings unchanged.
   """
 
   @doc """
@@ -52,6 +50,32 @@ defmodule LiveVue.Patch do
   """
   def serialize(patches) do
     :erlang.iolist_to_binary(for patch <- patches, do: serialize_op(patch))
+  end
+
+  @doc """
+  Encodes a JSON value for safe, compact HTML attribute transport.
+
+  The value is encoded with Jason's default JSON escaping, then JSON quote
+  characters are replaced with `^`. Literal `~` and `^` characters are escaped
+  as `~~` and `~^`, so the transform is reversible by `decode_object/1`.
+  """
+  def encode_object(value) do
+    value
+    |> Jason.encode!()
+    |> String.replace("~", "~~")
+    |> String.replace("^", "~^")
+    |> String.replace("\"", "^")
+  end
+
+  @doc false
+  def decode_object(value) when is_binary(value) do
+    value
+    |> String.replace(~r/~~|~\^|\^/, fn
+      "~~" -> "~"
+      "~^" -> "^"
+      "^" -> "\""
+    end)
+    |> Jason.decode!()
   end
 
   @doc """
@@ -81,16 +105,7 @@ defmodule LiveVue.Patch do
     [op_code(op), Integer.to_string(byte_size(path)), ?:, path]
   end
 
-  defp encode_path(""), do: ""
-
-  defp encode_path("/" <> rest) do
-    encode_path(rest, [])
-  end
-
-  defp encode_path(<<>>, acc), do: acc |> :lists.reverse() |> :erlang.iolist_to_binary()
-  defp encode_path(<<?/, rest::binary>>, acc), do: encode_path(rest, [?. | acc])
-  defp encode_path(<<?., rest::binary>>, acc), do: encode_path(rest, ["~2" | acc])
-  defp encode_path(<<char, rest::binary>>, acc), do: encode_path(rest, [char | acc])
+  defp encode_path(path), do: path
 
   defp encode_value(nil), do: "z"
   defp encode_value(true), do: "b1"
@@ -104,11 +119,7 @@ defmodule LiveVue.Patch do
   defp encode_value(value) when is_binary(value), do: ["s", Integer.to_string(byte_size(value)), ?:, value]
 
   defp encode_value(value) do
-    encoded =
-      value
-      |> Jason.encode!()
-      |> Base.url_encode64(padding: false)
-
+    encoded = encode_object(value)
     ["J", Integer.to_string(byte_size(encoded)), ?:, encoded]
   end
 
@@ -123,8 +134,6 @@ defmodule LiveVue.Patch do
     {path_length, rest} = take_length(rest)
     <<path::binary-size(path_length), rest::binary>> = rest
     op = op_from_code(code)
-    path = decode_path(path)
-
     parse_op(op, path, rest, acc)
   end
 
@@ -147,22 +156,11 @@ defmodule LiveVue.Patch do
       case tag do
         "n" -> parse_number(encoded)
         "s" -> encoded
-        "J" -> encoded |> Base.url_decode64!(padding: false) |> Jason.decode!()
+        "J" -> decode_object(encoded)
       end
 
     {value, rest}
   end
-
-  defp decode_path(""), do: ""
-
-  defp decode_path(path) do
-    :erlang.iolist_to_binary([?/ | decode_path(path, [])])
-  end
-
-  defp decode_path(<<>>, acc), do: :lists.reverse(acc)
-  defp decode_path(<<?., rest::binary>>, acc), do: decode_path(rest, [?/ | acc])
-  defp decode_path(<<?~, ?2, rest::binary>>, acc), do: decode_path(rest, [?. | acc])
-  defp decode_path(<<char, rest::binary>>, acc), do: decode_path(rest, [char | acc])
 
   defp parse_number(value) do
     case Integer.parse(value) do

--- a/lib/live_vue/test.ex
+++ b/lib/live_vue/test.ex
@@ -111,7 +111,7 @@ defmodule LiveVue.Test do
       vue_tree = find_component!(components, opts)
 
       %{
-        props: Jason.decode!(attr_from_tree(vue_tree, "data-props")),
+        props: LiveVue.Patch.decode_object(attr_from_tree(vue_tree, "data-props")),
         component: attr_from_tree(vue_tree, "data-name"),
         id: attr_from_tree(vue_tree, "id"),
         handlers: extract_handlers(attr_from_tree(vue_tree, "data-handlers")),

--- a/test/live_vue_patch_test.exs
+++ b/test/live_vue_patch_test.exs
@@ -48,6 +48,18 @@ defmodule LiveVuePatchTest do
 
       assert serialize_deserialize(patches) == patches
     end
+
+    test "round-trips caret-encoded JSON edge cases" do
+      patches = [
+        %{
+          op: "replace",
+          path: "/meta",
+          value: %{"empty" => "", "caret" => "^", "tilde" => "~", "both" => "~^"}
+        }
+      ]
+
+      assert serialize_deserialize(patches) == patches
+    end
   end
 
   describe "paths" do


### PR DESCRIPTION
## Summary
- encode full `data-props` with the compact caret JSON transport used by LiveVue patches
- replace base64url complex patch values with caret-encoded JSON and keep JSON Pointer paths unchanged
- update client decoding, tests, changelog, and patch wire-size benchmark scripts

## Benchmarks
`MIX_ENV=test mix run scripts/live_vue_patch_bench.exs --all-scenarios --time=0.1 --warmup=0 --memory-time=0 --reduction-time=0`

Across all scenarios:
- original pre-compact JSON-array wire payload: 4422 B
- previous compact/base64url wire payload: 1938 B (56.2% savings vs original)
- final caret JSON wire payload: 1851 B (58.1% savings vs original, 4.5% vs previous compact baseline)

## Tests
- `mix test`
- `npm test`
- `npm run e2e:test`