### PR TITLE
perf: speed up compact patch decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- %% CHANGELOG_ENTRIES %% -->
 
+## Unreleased
+
+### Improvements
+
+- Improved compact patch decoding performance by using JavaScript string lengths in the compact patch protocol ([#145](https://github.com/Valian/live_vue/pull/145)).
+
 ## 1.2.0 - 2026-05-06
 
 ### Improvements

--- a/assets/compactPatch.bench.ts
+++ b/assets/compactPatch.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from "vitest"
-import { applyCompactPatch, decodeCompactJson, decodeCompactPatch } from "./compactPatch"
+import { decodeCompactJson, decodeCompactPatch } from "./compactPatch"
 import { applyPatch } from "./jsonPatch"
 
 const textEncoder = new TextEncoder()
@@ -129,9 +129,7 @@ const realisticJsonValue = encodeJson({ articles: Array.from({ length: 30 }, (_,
 const decodeThenApplyDocument = {
   dashboard: { articles: Array.from({ length: 80 }, (_, index) => makeArticle(index)) },
 }
-const directApplyDocument = { dashboard: { articles: Array.from({ length: 80 }, (_, index) => makeArticle(index)) } }
 const scalarDecodeThenApplyDocument = makeScalarDocument()
-const scalarDirectApplyDocument = makeScalarDocument()
 const utf8Sample = Array.from({ length: 150 }, (_, index) => makeArticle(index).summary).join(" | ")
 const utf8SampleBytes = textEncoder.encode(utf8Sample).length
 
@@ -190,20 +188,13 @@ describe("decodeCompactPatch", () => {
 })
 
 describe("decode and apply compact patch", () => {
+  // Direct compact-patch application was benchmarked here and removed because it was not faster.
   bench("object-heavy: decode to operations, then apply", () => {
     applyPatch(decodeThenApplyDocument, decodeCompactPatch(realistic50kb))
   })
 
-  bench("object-heavy: apply while decoding", () => {
-    applyCompactPatch(directApplyDocument, realistic50kb)
-  })
-
   bench("scalar-heavy: decode to operations, then apply", () => {
     applyPatch(scalarDecodeThenApplyDocument, decodeCompactPatch(scalar50kb))
-  })
-
-  bench("scalar-heavy: apply while decoding", () => {
-    applyCompactPatch(scalarDirectApplyDocument, scalar50kb)
   })
 })
 

--- a/assets/compactPatch.bench.ts
+++ b/assets/compactPatch.bench.ts
@@ -1,0 +1,186 @@
+import { bench, describe } from "vitest"
+import { decodeCompactJson, decodeCompactPatch } from "./compactPatch"
+
+const textEncoder = new TextEncoder()
+
+const byteLength = (value: string) => textEncoder.encode(value).length
+
+const encodeJson = (value: unknown) => JSON.stringify(value).replace(/~/g, "~~").replace(/\^/g, "~^").replace(/"/g, "^")
+
+const field = (value: string) => `${byteLength(value)}:${value}`
+
+const valueField = (value: unknown) => {
+  if (value === null) return "z"
+  if (typeof value === "boolean") return value ? "b1" : "b0"
+  if (typeof value === "number") return `n${field(String(value))}`
+  if (typeof value === "string") return `s${field(value)}`
+  return `J${field(encodeJson(value))}`
+}
+
+const operation = (op: "a" | "d" | "r" | "u" | "l", path: string, value?: unknown) =>
+  op === "d" ? `${op}${field(path)}` : `${op}${field(path)}${valueField(value)}`
+
+const makeSyntheticPayload = (targetBytes: number) => {
+  let payload = "n12345"
+  let index = 0
+
+  while (payload.length < targetBytes) {
+    payload += operation("r", `/rows/${index}/name`, `row ${index} zażółć`)
+    payload += operation("r", `/rows/${index}/enabled`, index % 2 === 0)
+    payload += operation("u", `/rows/${index}`, {
+      id: index,
+      name: `Row ${index}`,
+      tags: [`tag-${index % 5}`, "vue", "liveview"],
+      nested: { count: index, active: index % 3 === 0 },
+    })
+    index++
+  }
+
+  return payload
+}
+
+const makeArticle = (index: number) => ({
+  id: index,
+  slug: `article-${index}`,
+  title: `LiveVue update ${index} 🚀 zażółć`,
+  summary:
+    `Moderate length text with UTF-8 characters: café, 東京, emoji ✨🔥, and caret ^ / tilde ~ markers. `.repeat(3) +
+    index,
+  author: {
+    id: `user-${index % 12}`,
+    name: `Author ${index % 12} Łukasz 😊`,
+    profile: {
+      timezone: "Europe/Warsaw",
+      bio: "Builds interfaces with Phoenix LiveView and Vue. Uses nested data often.",
+    },
+  },
+  stats: {
+    views: index * 137,
+    likes: index % 17,
+    featured: index % 11 === 0,
+    scores: [index, index + 1, index + 2, index + 3],
+  },
+  metadata: {
+    labels: [`team-${index % 4}`, "vue", "phoenix", "ssr"],
+    flags: { archived: false, reviewed: index % 3 === 0, pinned: index % 8 === 0 },
+    seo: {
+      title: `SEO title ${index}`,
+      description: "A longer nested string that resembles user-generated content and includes emoji 🧪.",
+    },
+  },
+})
+
+const makeRealisticPayload = (targetBytes: number) => {
+  let payload = "n987654"
+  let index = 0
+
+  while (payload.length < targetBytes) {
+    payload += operation("r", `/dashboard/articles/${index}/title`, `Updated title ${index} ✨`)
+    payload += operation(
+      "r",
+      `/dashboard/articles/${index}/metadata/seo/description`,
+      `Changed copy ${index} with emoji 😄`
+    )
+    payload += operation("u", `/dashboard/articles/${index}`, makeArticle(index))
+    payload += operation("l", "/dashboard/articles", -50)
+    index++
+  }
+
+  return payload
+}
+
+const synthetic5kb = makeSyntheticPayload(5_000)
+const synthetic25kb = makeSyntheticPayload(25_000)
+const synthetic50kb = makeSyntheticPayload(50_000)
+const realistic25kb = makeRealisticPayload(25_000)
+const realistic50kb = makeRealisticPayload(50_000)
+const realisticJsonValue = encodeJson({ articles: Array.from({ length: 30 }, (_, index) => makeArticle(index)) })
+const utf8Sample = Array.from({ length: 150 }, (_, index) => makeArticle(index).summary).join(" | ")
+const utf8SampleBytes = byteLength(utf8Sample)
+
+const findUtf8EndWithTextEncoder = (value: string, offset: number, bytesToRead: number) => {
+  let end = offset
+  let bytes = 0
+
+  while (end < value.length && bytes < bytesToRead) {
+    const codePoint = value.codePointAt(end)
+    if (codePoint === undefined) break
+
+    const char = String.fromCodePoint(codePoint)
+    bytes += textEncoder.encode(char).length
+    end += char.length
+  }
+
+  if (bytes !== bytesToRead) throw new Error("Invalid UTF-8 byte length")
+  return end
+}
+
+const findUtf8EndManually = (value: string, offset: number, bytesToRead: number) => {
+  let end = offset
+  let bytes = 0
+
+  while (end < value.length && bytes < bytesToRead) {
+    const code = value.charCodeAt(end)
+
+    if (code <= 0x7f) {
+      bytes++
+      end++
+    } else if (code <= 0x7ff) {
+      bytes += 2
+      end++
+    } else if (code >= 0xd800 && code <= 0xdbff && end + 1 < value.length) {
+      const next = value.charCodeAt(end + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4
+        end += 2
+      } else {
+        bytes += 3
+        end++
+      }
+    } else {
+      bytes += 3
+      end++
+    }
+  }
+
+  if (bytes !== bytesToRead) throw new Error("Invalid UTF-8 byte length")
+  return end
+}
+
+describe("decodeCompactPatch", () => {
+  bench("synthetic 5kb payload", () => {
+    decodeCompactPatch(synthetic5kb)
+  })
+
+  bench("synthetic 25kb payload", () => {
+    decodeCompactPatch(synthetic25kb)
+  })
+
+  bench("synthetic 50kb payload", () => {
+    decodeCompactPatch(synthetic50kb)
+  })
+
+  bench("realistic 25kb payload", () => {
+    decodeCompactPatch(realistic25kb)
+  })
+
+  bench("realistic 50kb payload", () => {
+    decodeCompactPatch(realistic50kb)
+  })
+})
+
+describe("decodeCompactJson", () => {
+  bench("realistic nested JSON value", () => {
+    decodeCompactJson(realisticJsonValue)
+  })
+})
+
+describe("UTF-8 byte scanning", () => {
+  bench("TextEncoder per character", () => {
+    findUtf8EndWithTextEncoder(utf8Sample, 0, utf8SampleBytes)
+  })
+
+  bench("manual byte count", () => {
+    findUtf8EndManually(utf8Sample, 0, utf8SampleBytes)
+  })
+})

--- a/assets/compactPatch.bench.ts
+++ b/assets/compactPatch.bench.ts
@@ -3,11 +3,11 @@ import { decodeCompactJson, decodeCompactPatch } from "./compactPatch"
 
 const textEncoder = new TextEncoder()
 
-const byteLength = (value: string) => textEncoder.encode(value).length
+const fieldLength = (value: string) => value.length
 
 const encodeJson = (value: unknown) => JSON.stringify(value).replace(/~/g, "~~").replace(/\^/g, "~^").replace(/"/g, "^")
 
-const field = (value: string) => `${byteLength(value)}:${value}`
+const field = (value: string) => `${fieldLength(value)}:${value}`
 
 const valueField = (value: unknown) => {
   if (value === null) return "z"
@@ -96,24 +96,7 @@ const realistic25kb = makeRealisticPayload(25_000)
 const realistic50kb = makeRealisticPayload(50_000)
 const realisticJsonValue = encodeJson({ articles: Array.from({ length: 30 }, (_, index) => makeArticle(index)) })
 const utf8Sample = Array.from({ length: 150 }, (_, index) => makeArticle(index).summary).join(" | ")
-const utf8SampleBytes = byteLength(utf8Sample)
-
-const findUtf8EndWithTextEncoder = (value: string, offset: number, bytesToRead: number) => {
-  let end = offset
-  let bytes = 0
-
-  while (end < value.length && bytes < bytesToRead) {
-    const codePoint = value.codePointAt(end)
-    if (codePoint === undefined) break
-
-    const char = String.fromCodePoint(codePoint)
-    bytes += textEncoder.encode(char).length
-    end += char.length
-  }
-
-  if (bytes !== bytesToRead) throw new Error("Invalid UTF-8 byte length")
-  return end
-}
+const utf8SampleBytes = textEncoder.encode(utf8Sample).length
 
 const findUtf8EndManually = (value: string, offset: number, bytesToRead: number) => {
   let end = offset
@@ -175,12 +158,12 @@ describe("decodeCompactJson", () => {
   })
 })
 
-describe("UTF-8 byte scanning", () => {
-  bench("TextEncoder per character", () => {
-    findUtf8EndWithTextEncoder(utf8Sample, 0, utf8SampleBytes)
+describe("field boundary detection", () => {
+  bench("UTF-8 byte scan", () => {
+    findUtf8EndManually(utf8Sample, 0, utf8SampleBytes)
   })
 
-  bench("manual byte count", () => {
-    findUtf8EndManually(utf8Sample, 0, utf8SampleBytes)
+  bench("JS string length", () => {
+    utf8Sample.slice(0, utf8Sample.length)
   })
 })

--- a/assets/compactPatch.bench.ts
+++ b/assets/compactPatch.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from "vitest"
-import { decodeCompactJson, decodeCompactPatch } from "./compactPatch"
+import { applyCompactPatch, decodeCompactJson, decodeCompactPatch } from "./compactPatch"
+import { applyPatch } from "./jsonPatch"
 
 const textEncoder = new TextEncoder()
 
@@ -40,6 +41,7 @@ const makeSyntheticPayload = (targetBytes: number) => {
 }
 
 const makeArticle = (index: number) => ({
+  __dom_id: `article-${index}`,
   id: index,
   slug: `article-${index}`,
   title: `LiveVue update ${index} 🚀 zażółć`,
@@ -70,6 +72,34 @@ const makeArticle = (index: number) => ({
   },
 })
 
+const makeScalarDocument = (rows = 300) => ({
+  dashboard: {
+    rows: Array.from({ length: rows }, (_, index) => ({
+      id: index,
+      title: `Title ${index}`,
+      count: index,
+      enabled: index % 2 === 0,
+      nested: { label: `Label ${index}`, score: index * 2 },
+    })),
+  },
+})
+
+const makeScalarPayload = (targetBytes: number) => {
+  let payload = "n246810"
+  let index = 0
+
+  while (payload.length < targetBytes) {
+    const row = index % 300
+    payload += operation("r", `/dashboard/rows/${row}/title`, `Updated ${index} ✨`)
+    payload += operation("r", `/dashboard/rows/${row}/count`, index)
+    payload += operation("r", `/dashboard/rows/${row}/enabled`, index % 2 === 0)
+    payload += operation("r", `/dashboard/rows/${row}/nested/label`, `Nested ${index} zażółć`)
+    index++
+  }
+
+  return payload
+}
+
 const makeRealisticPayload = (targetBytes: number) => {
   let payload = "n987654"
   let index = 0
@@ -94,7 +124,14 @@ const synthetic25kb = makeSyntheticPayload(25_000)
 const synthetic50kb = makeSyntheticPayload(50_000)
 const realistic25kb = makeRealisticPayload(25_000)
 const realistic50kb = makeRealisticPayload(50_000)
+const scalar50kb = makeScalarPayload(50_000)
 const realisticJsonValue = encodeJson({ articles: Array.from({ length: 30 }, (_, index) => makeArticle(index)) })
+const decodeThenApplyDocument = {
+  dashboard: { articles: Array.from({ length: 80 }, (_, index) => makeArticle(index)) },
+}
+const directApplyDocument = { dashboard: { articles: Array.from({ length: 80 }, (_, index) => makeArticle(index)) } }
+const scalarDecodeThenApplyDocument = makeScalarDocument()
+const scalarDirectApplyDocument = makeScalarDocument()
 const utf8Sample = Array.from({ length: 150 }, (_, index) => makeArticle(index).summary).join(" | ")
 const utf8SampleBytes = textEncoder.encode(utf8Sample).length
 
@@ -149,6 +186,24 @@ describe("decodeCompactPatch", () => {
 
   bench("realistic 50kb payload", () => {
     decodeCompactPatch(realistic50kb)
+  })
+})
+
+describe("decode and apply compact patch", () => {
+  bench("object-heavy: decode to operations, then apply", () => {
+    applyPatch(decodeThenApplyDocument, decodeCompactPatch(realistic50kb))
+  })
+
+  bench("object-heavy: apply while decoding", () => {
+    applyCompactPatch(directApplyDocument, realistic50kb)
+  })
+
+  bench("scalar-heavy: decode to operations, then apply", () => {
+    applyPatch(scalarDecodeThenApplyDocument, decodeCompactPatch(scalar50kb))
+  })
+
+  bench("scalar-heavy: apply while decoding", () => {
+    applyCompactPatch(scalarDirectApplyDocument, scalar50kb)
   })
 })
 

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -16,6 +16,12 @@ describe("decodeCompactPatch", () => {
     ])
   })
 
+  it("decodes escaped caret JSON values", () => {
+    expect(decodeCompactPatch("a5:/metaJ27:{^tilde^:^~~^,^caret^:^~^^}")).toEqual([
+      { op: "add", path: "/meta", value: { tilde: "~", caret: "^" } },
+    ])
+  })
+
   it("decodes JSON pointer paths", () => {
     expect(decodeCompactPatch("r21:/settings/a~1b~0c|d.es5:value")).toEqual([
       { op: "replace", path: "/settings/a~1b~0c|d.e", value: "value" },

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest"
-import { decodeCompactPatch } from "./compactPatch"
+import { applyCompactPatch, decodeCompactPatch } from "./compactPatch"
+
+describe("applyCompactPatch", () => {
+  it("applies compact patches directly", () => {
+    const document = { count: 1, items: ["a", "b", "c"] }
+
+    applyCompactPatch(document, "r6:/countn1:6r8:/items/1s1:dd8:/items/0")
+
+    expect(document).toEqual({ count: 6, items: ["d", "c"] })
+  })
+})
 
 describe("decodeCompactPatch", () => {
   it("decodes scalar add, replace, remove, and nonce operations", () => {

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -28,9 +28,10 @@ describe("decodeCompactPatch", () => {
     ])
   })
 
-  it("uses UTF-8 byte lengths for strings and paths", () => {
-    expect(decodeCompactPatch("r14:/profile/na.mes10:zażółć")).toEqual([
+  it("uses JavaScript string lengths for strings and paths", () => {
+    expect(decodeCompactPatch("r14:/profile/na.mes6:zażółćr6:/emojis2:🚀")).toEqual([
       { op: "replace", path: "/profile/na.me", value: "zażółć" },
+      { op: "replace", path: "/emoji", value: "🚀" },
     ])
   })
 

--- a/assets/compactPatch.test.ts
+++ b/assets/compactPatch.test.ts
@@ -1,15 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { applyCompactPatch, decodeCompactPatch } from "./compactPatch"
-
-describe("applyCompactPatch", () => {
-  it("applies compact patches directly", () => {
-    const document = { count: 1, items: ["a", "b", "c"] }
-
-    applyCompactPatch(document, "r6:/countn1:6r8:/items/1s1:dd8:/items/0")
-
-    expect(document).toEqual({ count: 6, items: ["d", "c"] })
-  })
-})
+import { decodeCompactPatch } from "./compactPatch"
 
 describe("decodeCompactPatch", () => {
   it("decodes scalar add, replace, remove, and nonce operations", () => {

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -1,4 +1,4 @@
-import type { Operation } from "./jsonPatch.js"
+import { applyPatchOperation, type Operation } from "./jsonPatch.js"
 
 export const decodeCompactPatch = (payload: string | null): Operation[] => {
   if (!payload) return []
@@ -99,6 +99,64 @@ const skipDigits = (payload: string, offset: number): number => {
   }
 
   return offset
+}
+
+export const applyCompactPatch = <T>(document: T, payload: string | null): T => {
+  if (!payload) return document
+
+  let result = document
+  let offset = 0
+
+  while (offset < payload.length) {
+    const code = payload[offset++]
+
+    if (code === "n") {
+      offset = skipDigits(payload, offset)
+      continue
+    }
+
+    const op = opFromCode(code)
+    const pathLength = readLength(payload, offset)
+    offset = pathLength.offset
+
+    const path = payload.slice(offset, offset + pathLength.value)
+    offset += pathLength.value
+
+    if (op === "remove") {
+      result = applyPatchOperation(result, op, path)
+      continue
+    }
+
+    const tag = payload[offset++]
+
+    if (tag === "z") {
+      result = applyPatchOperation(result, op, path, null)
+      continue
+    }
+
+    if (tag === "b") {
+      result = applyPatchOperation(result, op, path, payload[offset++] === "1")
+      continue
+    }
+
+    const valueLength = readLength(payload, offset)
+    offset = valueLength.offset
+
+    const rawValue = payload.slice(offset, offset + valueLength.value)
+    offset += valueLength.value
+
+    if (tag === "n") {
+      result = applyPatchOperation(result, op, path, Number(rawValue))
+    } else if (tag === "s") {
+      result = applyPatchOperation(result, op, path, rawValue)
+    } else if (tag === "J") {
+      result = applyPatchOperation(result, op, path, decodeCompactJson(rawValue))
+    } else {
+      throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
+    }
+  }
+
+  return result
 }
 
 export const decodeCompactJson = (value: string): any => {

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -1,4 +1,4 @@
-import { applyPatchOperation, type Operation } from "./jsonPatch.js"
+import type { Operation } from "./jsonPatch.js"
 
 export const decodeCompactPatch = (payload: string | null): Operation[] => {
   if (!payload) return []
@@ -99,64 +99,6 @@ const skipDigits = (payload: string, offset: number): number => {
   }
 
   return offset
-}
-
-export const applyCompactPatch = <T>(document: T, payload: string | null): T => {
-  if (!payload) return document
-
-  let result = document
-  let offset = 0
-
-  while (offset < payload.length) {
-    const code = payload[offset++]
-
-    if (code === "n") {
-      offset = skipDigits(payload, offset)
-      continue
-    }
-
-    const op = opFromCode(code)
-    const pathLength = readLength(payload, offset)
-    offset = pathLength.offset
-
-    const path = payload.slice(offset, offset + pathLength.value)
-    offset += pathLength.value
-
-    if (op === "remove") {
-      result = applyPatchOperation(result, op, path)
-      continue
-    }
-
-    const tag = payload[offset++]
-
-    if (tag === "z") {
-      result = applyPatchOperation(result, op, path, null)
-      continue
-    }
-
-    if (tag === "b") {
-      result = applyPatchOperation(result, op, path, payload[offset++] === "1")
-      continue
-    }
-
-    const valueLength = readLength(payload, offset)
-    offset = valueLength.offset
-
-    const rawValue = payload.slice(offset, offset + valueLength.value)
-    offset += valueLength.value
-
-    if (tag === "n") {
-      result = applyPatchOperation(result, op, path, Number(rawValue))
-    } else if (tag === "s") {
-      result = applyPatchOperation(result, op, path, rawValue)
-    } else if (tag === "J") {
-      result = applyPatchOperation(result, op, path, decodeCompactJson(rawValue))
-    } else {
-      throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
-    }
-  }
-
-  return result
 }
 
 export const decodeCompactJson = (value: string): any => {

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -18,9 +18,8 @@ export const decodeCompactPatch = (payload: string | null): Operation[] => {
     const pathLength = readLength(payload, offset)
     offset = pathLength.offset
 
-    const pathEnd = findUtf8End(payload, offset, pathLength.value)
-    const path = payload.slice(offset, pathEnd)
-    offset = pathEnd
+    const path = payload.slice(offset, offset + pathLength.value)
+    offset += pathLength.value
 
     if (op === "remove") {
       operations.push({ op, path })
@@ -42,9 +41,8 @@ export const decodeCompactPatch = (payload: string | null): Operation[] => {
     const valueLength = readLength(payload, offset)
     offset = valueLength.offset
 
-    const valueEnd = findUtf8End(payload, offset, valueLength.value)
-    const rawValue = payload.slice(offset, valueEnd)
-    offset = valueEnd
+    const rawValue = payload.slice(offset, offset + valueLength.value)
+    offset += valueLength.value
 
     if (tag === "n") {
       operations.push({ op, path, value: Number(rawValue) } as Operation)
@@ -101,39 +99,6 @@ const skipDigits = (payload: string, offset: number): number => {
   }
 
   return offset
-}
-
-const findUtf8End = (payload: string, offset: number, byteLength: number): number => {
-  let end = offset
-  let bytes = 0
-
-  while (end < payload.length && bytes < byteLength) {
-    const code = payload.charCodeAt(end)
-
-    if (code <= 0x7f) {
-      bytes++
-      end++
-    } else if (code <= 0x7ff) {
-      bytes += 2
-      end++
-    } else if (code >= 0xd800 && code <= 0xdbff && end + 1 < payload.length) {
-      const next = payload.charCodeAt(end + 1)
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        bytes += 4
-        end += 2
-      } else {
-        bytes += 3
-        end++
-      }
-    } else {
-      bytes += 3
-      end++
-    }
-  }
-
-  if (bytes !== byteLength) throw new Error("Invalid LiveVue patch UTF-8 byte length")
-
-  return end
 }
 
 export const decodeCompactJson = (value: string): any => {

--- a/assets/compactPatch.ts
+++ b/assets/compactPatch.ts
@@ -1,15 +1,5 @@
 import type { Operation } from "./jsonPatch.js"
 
-const opByCode: Record<string, Operation["op"]> = {
-  a: "add",
-  d: "remove",
-  r: "replace",
-  u: "upsert",
-  l: "limit",
-}
-
-const textEncoder = new TextEncoder()
-
 export const decodeCompactPatch = (payload: string | null): Operation[] => {
   if (!payload) return []
 
@@ -20,97 +10,138 @@ export const decodeCompactPatch = (payload: string | null): Operation[] => {
     const code = payload[offset++]
 
     if (code === "n") {
-      const result = readDigits(payload, offset)
-      offset = result.offset
+      offset = skipDigits(payload, offset)
       continue
     }
 
-    const op = opByCode[code]
-    if (!op) throw new Error(`Unknown LiveVue patch operation code: ${code}`)
-
+    const op = opFromCode(code)
     const pathLength = readLength(payload, offset)
     offset = pathLength.offset
 
-    const pathResult = readUtf8Bytes(payload, offset, pathLength.value)
-    offset = pathResult.offset
-    const path = pathResult.value
+    const pathEnd = findUtf8End(payload, offset, pathLength.value)
+    const path = payload.slice(offset, pathEnd)
+    offset = pathEnd
 
     if (op === "remove") {
       operations.push({ op, path })
       continue
     }
 
-    const valueResult = readValue(payload, offset)
-    offset = valueResult.offset
-    operations.push({ op, path, value: valueResult.value } as Operation)
+    const tag = payload[offset++]
+
+    if (tag === "z") {
+      operations.push({ op, path, value: null } as Operation)
+      continue
+    }
+
+    if (tag === "b") {
+      operations.push({ op, path, value: payload[offset++] === "1" } as Operation)
+      continue
+    }
+
+    const valueLength = readLength(payload, offset)
+    offset = valueLength.offset
+
+    const valueEnd = findUtf8End(payload, offset, valueLength.value)
+    const rawValue = payload.slice(offset, valueEnd)
+    offset = valueEnd
+
+    if (tag === "n") {
+      operations.push({ op, path, value: Number(rawValue) } as Operation)
+    } else if (tag === "s") {
+      operations.push({ op, path, value: rawValue } as Operation)
+    } else if (tag === "J") {
+      operations.push({ op, path, value: decodeCompactJson(rawValue) } as Operation)
+    } else {
+      throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
+    }
   }
 
   return operations
 }
 
-const readValue = (payload: string, offset: number): { value: any; offset: number } => {
-  const tag = payload[offset++]
-
-  switch (tag) {
-    case "z":
-      return { value: null, offset }
-    case "b":
-      return { value: payload[offset++] === "1", offset }
-    case "n": {
-      const result = readLengthPrefixed(payload, offset)
-      return { value: Number(result.value), offset: result.offset }
-    }
-    case "s":
-      return readLengthPrefixed(payload, offset)
-    case "J": {
-      const result = readLengthPrefixed(payload, offset)
-      return { value: decodeCompactJson(result.value), offset: result.offset }
-    }
+const opFromCode = (code: string): Operation["op"] => {
+  switch (code) {
+    case "a":
+      return "add"
+    case "d":
+      return "remove"
+    case "r":
+      return "replace"
+    case "u":
+      return "upsert"
+    case "l":
+      return "limit"
     default:
-      throw new Error(`Unknown LiveVue patch value tag: ${tag}`)
+      throw new Error(`Unknown LiveVue patch operation code: ${code}`)
   }
 }
 
-const readLengthPrefixed = (payload: string, offset: number): { value: string; offset: number } => {
-  const length = readLength(payload, offset)
-  const value = readUtf8Bytes(payload, length.offset, length.value)
-  return { value: value.value, offset: value.offset }
-}
-
 const readLength = (payload: string, offset: number): { value: number; offset: number } => {
-  const result = readDigits(payload, offset)
-  if (payload[result.offset] !== ":") throw new Error("Invalid LiveVue patch length prefix")
-  return { value: Number(result.value), offset: result.offset + 1 }
+  let value = 0
+  let hasDigits = false
+
+  while (offset < payload.length) {
+    const code = payload.charCodeAt(offset)
+    if (code < 48 || code > 57) break
+    value = value * 10 + code - 48
+    offset++
+    hasDigits = true
+  }
+
+  if (!hasDigits || payload[offset] !== ":") throw new Error("Invalid LiveVue patch length prefix")
+  return { value, offset: offset + 1 }
 }
 
-const readDigits = (payload: string, offset: number): { value: string; offset: number } => {
-  const start = offset
-  while (offset < payload.length && payload.charCodeAt(offset) >= 48 && payload.charCodeAt(offset) <= 57) offset++
-  return { value: payload.slice(start, offset), offset }
+const skipDigits = (payload: string, offset: number): number => {
+  while (offset < payload.length) {
+    const code = payload.charCodeAt(offset)
+    if (code < 48 || code > 57) break
+    offset++
+  }
+
+  return offset
 }
 
-const readUtf8Bytes = (payload: string, offset: number, byteLength: number): { value: string; offset: number } => {
+const findUtf8End = (payload: string, offset: number, byteLength: number): number => {
   let end = offset
   let bytes = 0
 
   while (end < payload.length && bytes < byteLength) {
-    const codePoint = payload.codePointAt(end)
-    if (codePoint === undefined) break
+    const code = payload.charCodeAt(end)
 
-    const char = String.fromCodePoint(codePoint)
-    bytes += textEncoder.encode(char).length
-    end += char.length
+    if (code <= 0x7f) {
+      bytes++
+      end++
+    } else if (code <= 0x7ff) {
+      bytes += 2
+      end++
+    } else if (code >= 0xd800 && code <= 0xdbff && end + 1 < payload.length) {
+      const next = payload.charCodeAt(end + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4
+        end += 2
+      } else {
+        bytes += 3
+        end++
+      }
+    } else {
+      bytes += 3
+      end++
+    }
   }
 
   if (bytes !== byteLength) throw new Error("Invalid LiveVue patch UTF-8 byte length")
 
-  return { value: payload.slice(offset, end), offset: end }
+  return end
 }
 
 export const decodeCompactJson = (value: string): any => {
-  return JSON.parse(value.replace(/~~|~\^|\^/g, match => {
-    if (match === "~~") return "~"
-    if (match === "~^") return "^"
-    return "\""
-  }))
+  return JSON.parse(
+    value.replace(/~~|~\^|\^/g, match => {
+      if (match === "~~") return "~"
+      if (match === "~^") return "^"
+      return '"'
+    })
+  )
 }

--- a/assets/jsonPatch.ts
+++ b/assets/jsonPatch.ts
@@ -87,10 +87,7 @@ function resolvePathComponent(component: string, arrayObj: any[]): string | null
     return component
   }
 
-  // Extract the ID from $$<id> syntax
   const targetId = component.substring(2)
-
-  // Find the index of the element with matching __dom_id
   const index = arrayObj.findIndex(item => item && typeof item === "object" && item.__dom_id == targetId)
 
   if (index === -1) {
@@ -99,6 +96,21 @@ function resolvePathComponent(component: string, arrayObj: any[]): string | null
   }
 
   return index.toString()
+}
+
+function readPathSegment(path: string, start: number, end: number): string {
+  const segment = path.slice(start, end)
+  return segment.indexOf("~") === -1 ? segment : unescapePathComponent(segment)
+}
+
+function resolveArrayIndex(key: string, arrayObj: any[], allowAppend: boolean): number | null {
+  if (key.startsWith("$$")) {
+    const resolved = resolvePathComponent(key, arrayObj)
+    return resolved === null ? null : parseInt(resolved, 10)
+  }
+
+  if (key === "-") return allowAppend ? arrayObj.length : arrayObj.length - 1
+  return parseInt(key, 10)
 }
 
 /**
@@ -136,160 +148,138 @@ export function getValueByPointer(document: any, pointer: string): any {
  * Modifies the original document to maintain Vue reactivity.
  */
 export function applyOperation<T>(document: T, operation: Operation): T {
-  // Handle root operations
-  if (operation.path === "") {
-    switch (operation.op) {
+  return applyPatchOperation(
+    document,
+    operation.op,
+    operation.path,
+    "value" in operation ? operation.value : undefined,
+    "from" in operation ? operation.from : undefined
+  )
+}
+
+export function applyPatchOperation<T>(
+  document: T,
+  op: Operation["op"],
+  path: string,
+  value?: AddOperation["value"],
+  from?: string
+): T {
+  if (path === "") {
+    switch (op) {
       case "add":
       case "replace":
-        return (operation as AddOperation | ReplaceOperation).value
+        return value
       case "move":
       case "copy":
-        return getValueByPointer(document, (operation as MoveOperation | CopyOperation).from)
+        return getValueByPointer(document, from || "")
       case "test":
-        return document // Test always returns original document
+        return document
       case "remove":
         return null as any
     }
   }
 
-  const keys = operation.path.split("/").slice(1) // remove empty first element
   let obj = document as any
+  let segmentStart = 1
 
-  // Navigate to parent object
-  for (let i = 0; i < keys.length - 1; i++) {
-    let key = keys[i].indexOf("~") !== -1 ? unescapePathComponent(keys[i]) : keys[i]
+  while (true) {
+    const segmentEnd = path.indexOf("/", segmentStart)
+    if (segmentEnd === -1) break
+
+    const key = readPathSegment(path, segmentStart, segmentEnd)
 
     if (Array.isArray(obj)) {
-      // Handle special $$id syntax for arrays
-      if (key.startsWith("$$")) {
-        const resolved = resolvePathComponent(key, obj)
-        if (resolved === null) {
-          return document // Skip operation if id not found
-        }
-        key = resolved
-      }
-      obj = obj[key === "-" ? obj.length - 1 : parseInt(key, 10)]
+      const index = resolveArrayIndex(key, obj, false)
+      if (index === null) return document
+      obj = obj[index]
     } else {
       obj = obj[key]
     }
+
+    segmentStart = segmentEnd + 1
   }
 
-  // Apply operation on final key
-  const finalKey = keys[keys.length - 1]
-  let unescapedKey = finalKey.indexOf("~") !== -1 ? unescapePathComponent(finalKey) : finalKey
+  const unescapedKey = readPathSegment(path, segmentStart, path.length)
 
   if (Array.isArray(obj)) {
     let index: number
 
-    // Handle special $$id syntax for arrays
-    if (unescapedKey.startsWith("$$")) {
-      const resolved = resolvePathComponent(unescapedKey, obj)
-      if (resolved === null) {
-        return document // Skip operation if id not found
-      }
-      index = parseInt(resolved, 10)
-    } else {
-      index = unescapedKey === "-" ? obj.length : parseInt(unescapedKey, 10)
-    }
+    const resolvedIndex = resolveArrayIndex(unescapedKey, obj, true)
+    if (resolvedIndex === null) return document
+    index = resolvedIndex
 
-    switch (operation.op) {
+    switch (op) {
       case "add":
-        obj.splice(index, 0, (operation as AddOperation).value)
+        obj.splice(index, 0, value)
         break
       case "remove":
         obj.splice(index, 1)
         break
       case "replace":
-        obj[index] = (operation as ReplaceOperation).value
+        obj[index] = value
         break
       case "upsert":
-        const upsertValue = (operation as UpsertOperation).value
-        // Check if item with same ID already exists in the array
-        if (upsertValue && typeof upsertValue === "object" && "__dom_id" in upsertValue) {
+        if (value && typeof value === "object" && "__dom_id" in value) {
           const existingIndex = obj.findIndex(
-            item => item && typeof item === "object" && item.__dom_id === upsertValue.__dom_id
+            item => item && typeof item === "object" && item.__dom_id === value.__dom_id
           )
 
           if (existingIndex !== -1) {
-            // Update existing item
-            obj[existingIndex] = upsertValue
+            obj[existingIndex] = value
           } else {
-            // Insert new item at specified index
-            obj.splice(index, 0, upsertValue)
+            obj.splice(index, 0, value)
           }
         } else {
-          // No ID to match against, just insert at specified index
-          obj.splice(index, 0, upsertValue)
+          obj.splice(index, 0, value)
         }
         break
       case "move":
-        const moveValue = getValueByPointer(document, (operation as MoveOperation).from)
-        if (moveValue === undefined) {
-          return document // Skip operation if source not found
-        }
-        applyOperation(document, { op: "remove", path: (operation as MoveOperation).from })
+        const moveValue = getValueByPointer(document, from || "")
+        if (moveValue === undefined) return document
+        applyPatchOperation(document, "remove", from || "")
         obj.splice(index, 0, moveValue)
         break
       case "copy":
-        const copyValue = getValueByPointer(document, (operation as CopyOperation).from)
-        obj.splice(index, 0, deepClone(copyValue))
+        obj.splice(index, 0, deepClone(getValueByPointer(document, from || "")))
         break
       case "test":
-        // Test operation - just return document unchanged
         break
       case "limit":
-        const limitValue = (operation as LimitOperation).value
-        if (limitValue >= 0) {
-          // Positive limit: keep first N elements, remove the rest
-          if (limitValue < obj.length) {
-            obj.splice(limitValue)
-          }
+        if (value >= 0) {
+          if (value < obj.length) obj.splice(value)
         } else {
-          // Negative limit: keep last N elements, remove from the beginning
-          const keepCount = Math.abs(limitValue)
-          if (keepCount < obj.length) {
-            obj.splice(0, obj.length - keepCount)
-          }
+          const keepCount = Math.abs(value)
+          if (keepCount < obj.length) obj.splice(0, obj.length - keepCount)
         }
         break
     }
   } else {
-    switch (operation.op) {
+    switch (op) {
       case "add":
       case "replace":
-        obj[unescapedKey] = (operation as AddOperation | ReplaceOperation).value
+        obj[unescapedKey] = value
         break
       case "remove":
         delete obj[unescapedKey]
         break
       case "move":
-        const moveValue = getValueByPointer(document, (operation as MoveOperation).from)
-        applyOperation(document, { op: "remove", path: (operation as MoveOperation).from })
+        const moveValue = getValueByPointer(document, from || "")
+        applyPatchOperation(document, "remove", from || "")
         obj[unescapedKey] = moveValue
         break
       case "copy":
-        const copyValue = getValueByPointer(document, (operation as CopyOperation).from)
-        obj[unescapedKey] = deepClone(copyValue)
+        obj[unescapedKey] = deepClone(getValueByPointer(document, from || ""))
         break
       case "test":
-        // Test operation - just return document unchanged
         break
       case "limit":
-        // Check if target is an array
         const targetArray = obj[unescapedKey]
         if (Array.isArray(targetArray)) {
-          const limitValue = (operation as LimitOperation).value
-          if (limitValue >= 0) {
-            // Positive limit: keep first N elements, remove the rest
-            if (limitValue < targetArray.length) {
-              targetArray.splice(limitValue)
-            }
+          if (value >= 0) {
+            if (value < targetArray.length) targetArray.splice(value)
           } else {
-            // Negative limit: keep last N elements, remove from the beginning
-            const keepCount = Math.abs(limitValue)
-            if (keepCount < targetArray.length) {
-              targetArray.splice(0, targetArray.length - keepCount)
-            }
+            const keepCount = Math.abs(value)
+            if (keepCount < targetArray.length) targetArray.splice(0, targetArray.length - keepCount)
           }
         }
         break

--- a/lib/live_vue/patch.ex
+++ b/lib/live_vue/patch.ex
@@ -4,8 +4,8 @@ defmodule LiveVue.Patch do
   `data-props-diff` and `data-streams-diff`.
 
   The payload is a concatenated sequence of operations. Dynamic text fields are
-  byte-length-prefixed, so paths and values can contain delimiters without extra
-  escaping.
+  JavaScript-string-length-prefixed, so paths and values can contain delimiters
+  without extra escaping.
 
   Operation codes:
 
@@ -21,7 +21,7 @@ defmodule LiveVue.Patch do
   Normal operations use:
 
   ```text
-  <op><path_byte_len>:<path><value>
+  <op><path_len>:<path><value>
   ```
 
   `remove` omits `<value>`. The nonce marker uses `n<digits>` and exists only
@@ -34,7 +34,7 @@ defmodule LiveVue.Patch do
   | `z` | `nil` |
   | `b0`, `b1` | booleans |
   | `n<len>:<number>` | number |
-  | `s<len>:<utf8 string>` | string |
+  | `s<len>:<string>` | string |
   | `J<len>:<caret-encoded JSON>` | maps, lists, and complex values |
 
   Paths are transported as JSON Pointer strings unchanged.
@@ -97,12 +97,12 @@ defmodule LiveVue.Patch do
 
   defp serialize_op(%{op: op, path: path, value: value}) do
     path = encode_path(path)
-    [op_code(op), Integer.to_string(byte_size(path)), ?:, path, encode_value(value)]
+    [op_code(op), Integer.to_string(js_string_length(path)), ?:, path, encode_value(value)]
   end
 
   defp serialize_op(%{op: op, path: path}) do
     path = encode_path(path)
-    [op_code(op), Integer.to_string(byte_size(path)), ?:, path]
+    [op_code(op), Integer.to_string(js_string_length(path)), ?:, path]
   end
 
   defp encode_path(path), do: path
@@ -113,14 +113,14 @@ defmodule LiveVue.Patch do
 
   defp encode_value(value) when is_number(value) do
     encoded = to_string(value)
-    ["n", Integer.to_string(byte_size(encoded)), ?:, encoded]
+    ["n", Integer.to_string(js_string_length(encoded)), ?:, encoded]
   end
 
-  defp encode_value(value) when is_binary(value), do: ["s", Integer.to_string(byte_size(value)), ?:, value]
+  defp encode_value(value) when is_binary(value), do: ["s", Integer.to_string(js_string_length(value)), ?:, value]
 
   defp encode_value(value) do
     encoded = encode_object(value)
-    ["J", Integer.to_string(byte_size(encoded)), ?:, encoded]
+    ["J", Integer.to_string(js_string_length(encoded)), ?:, encoded]
   end
 
   defp parse_ops("", acc), do: acc
@@ -132,7 +132,7 @@ defmodule LiveVue.Patch do
 
   defp parse_ops(<<code::binary-size(1), rest::binary>>, acc) do
     {path_length, rest} = take_length(rest)
-    <<path::binary-size(path_length), rest::binary>> = rest
+    {path, rest} = take_js_string(rest, path_length)
     op = op_from_code(code)
     parse_op(op, path, rest, acc)
   end
@@ -150,7 +150,7 @@ defmodule LiveVue.Patch do
 
   defp parse_value(<<tag::binary-size(1), rest::binary>>) when tag in ["n", "s", "J"] do
     {length, rest} = take_length(rest)
-    <<encoded::binary-size(length), rest::binary>> = rest
+    {encoded, rest} = take_js_string(rest, length)
 
     value =
       case tag do
@@ -185,6 +185,33 @@ defmodule LiveVue.Patch do
   end
 
   defp take_digits(rest, acc), do: {acc, rest}
+
+  defp take_js_string(payload, length), do: take_js_string(payload, payload, length, 0)
+
+  defp take_js_string(original, _rest, 0, bytes) do
+    <<value::binary-size(bytes), rest::binary>> = original
+    {value, rest}
+  end
+
+  defp take_js_string(original, <<codepoint::utf8, rest::binary>>, remaining, bytes) do
+    units = js_code_units(codepoint)
+    if units > remaining, do: raise(ArgumentError, "Invalid LiveVue patch length prefix")
+    take_js_string(original, rest, remaining - units, bytes + utf8_byte_size(codepoint))
+  end
+
+  defp js_string_length(value), do: js_string_length(value, 0)
+  defp js_string_length(<<>>, acc), do: acc
+
+  defp js_string_length(<<codepoint::utf8, rest::binary>>, acc),
+    do: js_string_length(rest, acc + js_code_units(codepoint))
+
+  defp js_code_units(codepoint) when codepoint > 0xFFFF, do: 2
+  defp js_code_units(_codepoint), do: 1
+
+  defp utf8_byte_size(codepoint) when codepoint <= 0x7F, do: 1
+  defp utf8_byte_size(codepoint) when codepoint <= 0x7FF, do: 2
+  defp utf8_byte_size(codepoint) when codepoint <= 0xFFFF, do: 3
+  defp utf8_byte_size(_codepoint), do: 4
 
   defp op_code("add"), do: "a"
   defp op_code("remove"), do: "d"

--- a/mix.exs
+++ b/mix.exs
@@ -118,7 +118,7 @@ defmodule LiveVue.MixProject do
         GitHub: @repo_url
       },
       files: ~w(assets lib mix.exs package.json .formatter.exs LICENSE.md README.md CHANGELOG.md usage-rules.md),
-      exclude_patterns: [~r/\.test\.ts$/, ~r/assets\/tests\//]
+      exclude_patterns: [~r/\.test\.[jt]s$/, ~r/\.bench\.ts$/, ~r/assets\/tests\//]
     ]
   end
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",
+    "bench": "vitest bench",
     "e2e:install": "npx playwright install --with-deps chromium",
     "e2e:server": "MIX_ENV=e2e mix run test/e2e/test_helper.exs",
     "e2e:build": "npx vite build --config test/e2e/vite.config.js && npx vite build --config test/e2e/vite.config.js --ssr test/e2e/js/server.js",

--- a/test/live_vue_patch_test.exs
+++ b/test/live_vue_patch_test.exs
@@ -99,9 +99,13 @@ defmodule LiveVuePatchTest do
       assert serialize_deserialize(patches) == patches
     end
 
-    test "round-trips UTF-8 paths and values using byte lengths" do
-      patches = [%{op: "replace", path: "/profile/na.me", value: "zażółć"}]
+    test "round-trips UTF-8 paths and values using JavaScript string lengths" do
+      patches = [
+        %{op: "replace", path: "/profile/na.me", value: "zażółć"},
+        %{op: "replace", path: "/emoji", value: "🚀"}
+      ]
 
+      assert Patch.serialize(patches) == "r14:/profile/na.mes6:zażółćr6:/emojis2:🚀"
       assert serialize_deserialize(patches) == patches
     end
   end


### PR DESCRIPTION
## Summary
- optimize compact patch decoding by removing per-character TextEncoder work and parsing length prefixes directly
- switch compact patch field lengths to JavaScript string lengths, so the client can slice without UTF-8 boundary scanning
- add realistic Vitest benchmarks for compact patch decoding, JSON decoding, and decode+apply end-to-end performance
- refactor JSON Patch application to scan path segments without allocating split/slice arrays

## Benchmarks
- original realistic 50kb decode in Chrome: ~36ms
- optimized realistic 50kb decode in Chrome: ~0.22ms
- apply path scanner: ~22% faster apply-only, ~5% faster end-to-end

## Test plan
- [x] mix test test/live_vue_patch_test.exs
- [x] npm test -- assets/compactPatch.test.ts assets/jsonPatch.test.ts --run
- [x] npx tsc --noEmit
- [x] npm run bench -- assets/compactPatch.bench.ts --run
