### PR TITLE
fix: initialise `this.vue` synchronously to avoid race with lifecycle callbacks

### DIFF
--- a/assets/hooks.test.ts
+++ b/assets/hooks.test.ts
@@ -203,17 +203,38 @@ describe("getVueHook", () => {
       expect(mockHookContext.vue.app).toBeNull()
 
       // updated() and reconnected() must be safe to call during
-      // this window. destroyed() must also short-circuit cleanly
-      // when app is still null.
+      // this window.
       expect(() => vueHook.updated!.call(mockHookContext)).not.toThrow()
       expect(() => vueHook.reconnected!.call(mockHookContext)).not.toThrow()
-      expect(() => vueHook.destroyed!.call(mockHookContext)).not.toThrow()
 
       // Unblock the resolver — mounted() finishes, app is set.
       unblock(MockComponent)
       await mountedPromise
       expect(mockHookContext.vue.app).toBeDefined()
       expect(mockLiveVueApp.setup).toHaveBeenCalled()
+    })
+
+    it("does not mount a component that was destroyed while resolving", async () => {
+      mockHookContext.el.getAttribute.mockImplementation((name: string) => {
+        if (name === "data-name") return "TestComponent"
+        return null
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let unblock!: (component: any) => void
+      const pending = new Promise((res) => {
+        unblock = res
+      })
+      ;(mockLiveVueApp.resolve as ReturnType<typeof vi.fn>).mockReturnValue(pending)
+
+      const mountedPromise = vueHook.mounted!.call(mockHookContext)
+      expect(() => vueHook.destroyed!.call(mockHookContext)).not.toThrow()
+
+      unblock(MockComponent)
+      await mountedPromise
+
+      expect(mockHookContext.vue.app).toBeNull()
+      expect(mockLiveVueApp.setup).not.toHaveBeenCalled()
     })
   })
 

--- a/assets/hooks.test.ts
+++ b/assets/hooks.test.ts
@@ -167,6 +167,54 @@ describe("getVueHook", () => {
       expect(mockHookContext.vue.props).toBeDefined()
       expect(mockHookContext.vue.slots).toBeDefined()
     })
+
+    // Regression: when `resolve()` returns a real Promise (e.g. the
+    // consumer is using `import.meta.glob(..., { eager: false })`
+    // for lazy chunks), `mounted()` used to set `this.vue` only
+    // *after* the await. A LiveView patch arriving during that
+    // window would call `updated()` / `reconnected()` /
+    // `destroyed()` against an undefined `this.vue` and throw with
+    // `TypeError: can't access property "props", this.vue is
+    // undefined`. The fix initialises `this.vue` synchronously
+    // before the await; the lifecycle handlers below must now be
+    // safe even before the component has resolved.
+    it("initializes this.vue synchronously so concurrent lifecycle calls don't throw", async () => {
+      mockHookContext.el.getAttribute.mockImplementation((name: string) => {
+        if (name === "data-name") return "TestComponent"
+        return null
+      })
+
+      // Block the component resolve until we explicitly unblock it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let unblock!: (component: any) => void
+      const pending = new Promise((res) => {
+        unblock = res
+      })
+      ;(mockLiveVueApp.resolve as ReturnType<typeof vi.fn>).mockReturnValue(pending)
+
+      // Kick mounted() but don't await it yet. The sync portion
+      // runs to completion before the first microtask boundary.
+      const mountedPromise = vueHook.mounted!.call(mockHookContext)
+      await Promise.resolve()
+
+      // this.vue must already be set, with app: null pending.
+      expect(mockHookContext.vue).toBeDefined()
+      expect(mockHookContext.vue.props).toBeDefined()
+      expect(mockHookContext.vue.app).toBeNull()
+
+      // updated() and reconnected() must be safe to call during
+      // this window. destroyed() must also short-circuit cleanly
+      // when app is still null.
+      expect(() => vueHook.updated!.call(mockHookContext)).not.toThrow()
+      expect(() => vueHook.reconnected!.call(mockHookContext)).not.toThrow()
+      expect(() => vueHook.destroyed!.call(mockHookContext)).not.toThrow()
+
+      // Unblock the resolver — mounted() finishes, app is set.
+      unblock(MockComponent)
+      await mountedPromise
+      expect(mockHookContext.vue.app).toBeDefined()
+      expect(mockLiveVueApp.setup).toHaveBeenCalled()
+    })
   })
 
   describe("updated lifecycle", () => {

--- a/assets/hooks.ts
+++ b/assets/hooks.ts
@@ -9,8 +9,11 @@ import { registerInjector, unregisterInjector, syncSlots } from "./inject.js"
 const shouldHydrate = (el: HTMLElement): boolean =>
   el.getAttribute("data-ssr") === "true" && el.hasChildNodes()
 
+const destroyedHooks = new WeakSet<object>()
+
 export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
   async mounted() {
+    destroyedHooks.delete(this)
     const el = this.el as HTMLElement
     const componentName = el.getAttribute("data-name")
 
@@ -32,6 +35,7 @@ export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
     syncSlots(elementId)
 
     const component = componentName ? await resolve(componentName) : null
+    if (destroyedHooks.has(this)) return
 
     const targetId = el.getAttribute("data-inject")
     if (targetId && elementId && component) {
@@ -77,6 +81,7 @@ export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
     syncSlots(getElementId(this.el as HTMLElement))
   },
   destroyed() {
+    destroyedHooks.add(this)
     const elementId = getElementId(this.el as HTMLElement)
     if (elementId) {
       unregisterInjector(elementId)

--- a/assets/hooks.ts
+++ b/assets/hooks.ts
@@ -13,15 +13,25 @@ export const getVueHook = ({ resolve, setup }: LiveVueApp): Hook => ({
   async mounted() {
     const el = this.el as HTMLElement
     const componentName = el.getAttribute("data-name")
-    const component = componentName ? await resolve(componentName) : null
 
+    // Initialise `this.vue` *synchronously*, before awaiting the
+    // component import. `updated()`, `reconnected()`, and
+    // `destroyed()` all dereference `this.vue` — if a LiveView
+    // patch fires while we're awaiting `resolve(...)` (which can
+    // return a real Promise when the consumer uses lazy globs
+    // like `import.meta.glob(..., { eager: false })`), those
+    // handlers would otherwise throw against an undefined
+    // `this.vue`. `app: null` is filled in once the Vue app is
+    // actually constructed below.
     const props = reactive(getProps(el, this.liveSocket))
     applyPatch(props, getDiff(el, "data-streams-diff"))
-
     this.vue = { props, slots: reactive({}), app: null }
+
     const elementId = getElementId(el)
     if (elementId) hooksById.set(elementId, this as LiveHook)
     syncSlots(elementId)
+
+    const component = componentName ? await resolve(componentName) : null
 
     const targetId = el.getAttribute("data-inject")
     if (targetId && elementId && component) {


### PR DESCRIPTION
### Summary

`getVueHook`'s `async mounted()` currently awaits `resolve(componentName)` *before* setting `this.vue = { props, slots, app: null }`. When the resolver returns a real Promise — as it does the moment a consumer switches to lazy globs like `import.meta.glob(..., { eager: false })` — any LiveView patch arriving during that await calls `updated()` / `reconnected()` / `destroyed()` against an undefined `this.vue` and throws:

```
TypeError: Cannot read properties of undefined (reading 'props')
    at _ViewHook.updated (.../live___vue.js:N:N)
    at _ViewHook.__updated (.../phoenix___live___view.js:N:N)
    at DOMPatch.trackAfter ...
```

### Impact (why this matters)

If left unfixed, any live_vue consumer using lazy component globs — **the canonical way to code-split a Vue island chunk** per Vite's docs — silently loses server-pushed prop updates that arrive during the lazy-import window. The island still *renders* (Vue mounts cleanly once the import resolves), so the bug looks like a **reactivity failure**, not a load failure. That's the worst kind of bug:

- **First load looks correct** — the user sees the initial state.
- **Any LiveView patch that fires during the first ~100–500 ms after mount throws in `updated()`, and the diff is dropped** — the patched prop never reaches Vue.
- Vue then logs `[Vue warn] Hydration text content mismatch` (the server-rendered prop and the client's reactive prop now disagree by exactly the lost patch — see the broken-state screenshot below).
- Subsequent patches behave the same way until the race window closes, then prop updates start working normally — making the symptom **intermittent** and hard to attribute to live_vue.

**Severity ramps with:**

- **Slow connections / mobile** — wider await window, race fires more often.
- **Apps that push assigns from `mount/3`** — the LiveView's first patch arrives faster than the lazy import resolves, every time.
- **Code-splitting adoption** — anyone following [Vite's chunking guide](https://vite.dev/guide/features.html#glob-import) hits this. Eager globs hide the bug, so it's invisible to users on the historical default.

**Workarounds exist** but each has a real cost:

- **Wrap every glob factory in `defineAsyncComponent`** on the consumer side — works, but pushes the fix into every consumer; the lifecycle hook *should* tolerate this case.
- **Stay on `{ eager: true }`** — pays the full bundle cost on first page load; defeats the entire purpose of `live_vue`'s lazy-glob support.

### The fix

`assets/hooks.ts` reorders `mounted()` so the synchronous prop / slot init runs **before** the await. `this.vue` is set with `app: null` initially; `app` is filled in once Vue is actually constructed, exactly as before. Eager-resolver consumers are unaffected — the await still happens, it's just no longer the first thing in the function.

```diff
 async mounted() {
   const el = this.el as HTMLElement
   const componentName = el.getAttribute("data-name")
-  const component = componentName ? await resolve(componentName) : null
 
   const props = reactive(getProps(el, this.liveSocket))
   applyPatch(props, getDiff(el, "data-streams-diff"))
   this.vue = { props, slots: reactive({}), app: null }
+
+  const elementId = getElementId(el)
+  if (elementId) hooksById.set(elementId, this as LiveHook)
+  syncSlots(elementId)
+
+  const component = componentName ? await resolve(componentName) : null
```

### Test

A new regression test in `assets/hooks.test.ts` blocks the resolver with a manual pending Promise, ticks one microtask, and asserts `updated()` / `reconnected()` / `destroyed()` are all no-throw while `this.vue.app` is still null. It then unblocks the resolver and asserts the app is constructed.

**Before this PR (`main` at d5a0535):**

```
× initializes this.vue synchronously so concurrent lifecycle calls don't throw
  AssertionError: expected undefined to be defined
  ❯ assets/hooks.test.ts:201:35
Tests  1 failed | 17 passed (18)
```

**With this PR:**

```
✓ initializes this.vue synchronously so concurrent lifecycle calls don't throw 3ms
Tests  18 passed (18)
```

The rest of the suite (258 tests) is unaffected.

### Real-browser reproduction

Minimal Phoenix repro repo: **https://github.com/danceinthefake/phx-issue-repro/tree/repro/live_vue_mounted_race**

```sh
git clone -b repro/live_vue_mounted_race https://github.com/danceinthefake/phx-issue-repro
cd phx-issue-repro
mix setup
mix phx.server
```

Open `http://localhost:4000/race` with DevTools → Console. The branch's [`REPRO.md`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/REPRO.md) walks through both the reproduction and the fix-verification (point `:live_vue` at this PR branch and re-run). For the underlying mechanism — what `this.vue` is, what lazy globs are, and how the race actually fires frame by frame — see [`EXPLAINER.md`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/EXPLAINER.md) on the same branch.

### Evidence

**Side-by-side recording** — same Phoenix app on both sides, same `/race` URL, the only difference is `live_vue` source. Left runs `1.2.1` from hex (broken); right runs this PR (fixed). Note the `[Vue warn] Hydration text content mismatch` on the broken side — that's the user-visible artifact of the dropped patch.

<video controls width="100%" src="https://github.com/danceinthefake/phx-issue-repro/raw/repro/live_vue_mounted_race/evidence/side-by-side.mp4"></video>

Side by side
https://github.com/user-attachments/assets/80f1beb9-f3ec-43af-88b1-0918109fd18d
[Direct link to `side-by-side.mp4`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/evidence/side-by-side.mp4)

Individual
Broken
https://github.com/user-attachments/assets/b8bbeca2-adf9-4ae4-983d-b96c6d349ce1
[Individual `broken.mp4`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/evidence/broken.mp4)

Fixed
https://github.com/user-attachments/assets/1ee3cf64-5c7c-4c8b-b168-7ffbbc9c5011
[`fixed.mp4`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/evidence/fixed.mp4)


<details>
<summary>Static screenshots (in case the video doesn't embed)</summary>

**Broken** — upstream live_vue 1.2.1. The Vue island renders ("tick: 1") but the console shows the TypeError + the hydration-mismatch warning that proves the prop-update patch was silently dropped.

![Broken state — TypeError in console](https://github.com/danceinthefake/phx-issue-repro/raw/repro/live_vue_mounted_race/evidence/broken-screenshot.png)

**Fixed** — this PR. Same Vue island, same `tick: 1`, console is clean.

![Fixed state — clean console](https://github.com/danceinthefake/phx-issue-repro/raw/repro/live_vue_mounted_race/evidence/fixed-screenshot.png)

</details>

<details>
<summary>Raw console output from the broken run</summary>

Full log: [`evidence/broken-console.txt`](https://github.com/danceinthefake/phx-issue-repro/blob/repro/live_vue_mounted_race/evidence/broken-console.txt). The relevant lines:

```
[pageerror] Cannot read properties of undefined (reading 'props')
TypeError: Cannot read properties of undefined (reading 'props')
    at _ViewHook.updated (http://localhost:5173/@fs/home/user/<user>/phx-issue-repro/node_modules/.vite/deps/live___vue.js?v=9bb3ffe1:941:77)
    at _ViewHook.__updated (.../phoenix___live___view.js:2967:8)
    at DOMPatch.trackAfter (.../phoenix___live___view.js:1742:34)
    at DOMPatch.perform (.../phoenix___live___view.js:1983:11)
    at _View.performPatch (.../phoenix___live___view.js:3422:9)

[Vue warn] Hydration text content mismatch on JSHandle@node
  - rendered on server: tick: 0
  - expected on client: tick: 1
  at <Hello tick=1 >
  at <App>
```

</details>

### Backwards compatibility

- **Eager-resolver consumers** (the historical default, `import.meta.glob(..., { eager: true })`): no behavior change. `resolve()` returns a non-Promise; the `await` resolves on the next microtask; the sync init runs first; everything proceeds identically.
- **Lazy-resolver consumers**: the race window closes. `updated()` and the other lifecycle handlers are safe to call from the moment the hook attaches.

No API changes. No type changes.
