### PR TITLE
fix: avoid deprecated TagEngine EEx usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- %% CHANGELOG_ENTRIES %% -->
 
+## Unreleased
+
+### Bug Fixes
+
+- Avoided deprecated `Phoenix.LiveView.TagEngine` EEx usage on LiveView 1.2 while retaining compatibility with older LiveView versions ([#149](https://github.com/Valian/live_vue/pull/149)).
+
 ## 1.2.1 - 2026-05-10
 
 ### Improvements

--- a/lib/live_vue/shared_props_view.ex
+++ b/lib/live_vue/shared_props_view.ex
@@ -45,6 +45,9 @@ defmodule LiveVue.SharedPropsView do
   LiveView's reactivity since the props appear as regular template expressions.
   """
 
+  alias Phoenix.LiveView.HTMLEngine
+  alias Phoenix.LiveView.TagEngine
+
   @shared_props_config Application.compile_env(:live_vue, :shared_props, [])
 
   @doc """
@@ -249,15 +252,27 @@ defmodule LiveVue.SharedPropsView do
     end
   end
 
-  defp compile_heex(expr, meta, caller) do
-    EEx.compile_string(expr,
-      engine: Phoenix.LiveView.TagEngine,
-      source: expr,
-      file: caller.file,
-      line: caller.line + 1,
-      caller: caller,
-      indentation: meta[:indentation] || 0,
-      tag_handler: Phoenix.LiveView.HTMLEngine
-    )
+  if function_exported?(TagEngine, :compile, 2) do
+    defp compile_heex(expr, meta, caller) do
+      TagEngine.compile(expr,
+        file: caller.file,
+        line: caller.line + 1,
+        caller: caller,
+        indentation: meta[:indentation] || 0,
+        tag_handler: HTMLEngine
+      )
+    end
+  else
+    defp compile_heex(expr, meta, caller) do
+      EEx.compile_string(expr,
+        engine: TagEngine,
+        source: expr,
+        file: caller.file,
+        line: caller.line + 1,
+        caller: caller,
+        indentation: meta[:indentation] || 0,
+        tag_handler: HTMLEngine
+      )
+    end
   end
 end

--- a/test/live_vue_shared_props_view_test.exs
+++ b/test/live_vue_shared_props_view_test.exs
@@ -56,6 +56,28 @@ defmodule LiveVue.SharedPropsViewTest do
     {:current_user, :current_user}
   ]
 
+  test "~H sigil does not use TagEngine as an EEx engine when compile/2 is available" do
+    warnings =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        Code.compile_string(~S'''
+        defmodule LiveVue.SharedPropsNoDeprecationWarning do
+          use Phoenix.Component
+
+          import Phoenix.Component, except: [sigil_H: 2]
+          import LiveVue.SharedPropsView, only: [sigil_H: 2]
+
+          def render(assigns) do
+            ~H"""
+            <div>{@message}</div>
+            """
+          end
+        end
+        ''')
+      end)
+
+    refute warnings =~ "Using Phoenix.LiveView.TagEngine as an EEx.Engine is deprecated"
+  end
+
   describe "inject_shared_props_in_vue/2" do
     test "injects shared attrs into .vue component" do
       input = """


### PR DESCRIPTION
## Summary

- compile rewritten HEEx through `Phoenix.LiveView.TagEngine.compile/2` when available
- retain the existing EEx compilation path for older LiveView versions
- add a regression test ensuring the LiveView 1.2 deprecation warning is not emitted

Fixes #148.

## Tests

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test` — 230 tests passed
- `npx tsc --noEmit`
- `npm test` — 258 tests passed
- `npm run e2e:test` — 94 tests passed
- isolated fallback compilation with Phoenix LiveView 0.20.17
- verified the new path with Phoenix LiveView 1.2.7
